### PR TITLE
내 맞춤 정보 설정 UI 작업

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  input[type="number"]::-webkit-inner-spin-button,
+  input[type="number"]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko" className={inter.className}>
-      <body className="flex flex-col w-full px-4 lg:px-0 max-w-screen-lg mx-auto">
+      <body className="flex flex-col w-full px-4 lg:px-0 max-w-screen-lg mx-auto mb-[6rem] md:mb-0">
         <Header />
         <main className="grow">{children}</main>
         <MobileNavbar />

--- a/app/user/mysize/edit/page.tsx
+++ b/app/user/mysize/edit/page.tsx
@@ -1,9 +1,28 @@
+import MobileSection from '@/components/MobileSection';
+import MyPageSection from '@/components/MyPage/MyPageSection';
+import EditForm from '@/components/MyPage/MySize/EditForm';
+import GuidelinePic from '@/components/MyPage/MySize/GuidelinePic';
+import { getMySize } from '@/service/mysize';
+
 import React from 'react';
 
 type Props = {};
 
-function MySizeEditPage(props: Props) {
-  return <div>내 맞춤 정보 수정</div>;
+async function MySizeEditPage(props: Props) {
+  const mySize = await getMySize();
+  return (
+    <>
+      <MyPageSection
+        sectionName="내 맞춤 정보 설정"
+        displayStyle="hidden md:block"
+      />
+      <MobileSection sectionName="내 맞춤 정보 설정" />
+      <div className="flex flex-col gap-8 md:gap-12 w-full md:flex-row">
+        <GuidelinePic />
+        <EditForm mySize={mySize} />
+      </div>
+    </>
+  );
 }
 
 export default MySizeEditPage;

--- a/app/user/mysize/edit/page.tsx
+++ b/app/user/mysize/edit/page.tsx
@@ -17,7 +17,7 @@ async function MySizeEditPage(props: Props) {
         displayStyle="hidden md:block"
       />
       <MobileSection sectionName="내 맞춤 정보 설정" />
-      <div className="flex flex-col gap-8 md:gap-12 w-full md:flex-row">
+      <div className="flex flex-col gap-8 md:gap-12 w-full md:flex-row md:portrait:flex-col">
         <GuidelinePic />
         <EditForm mySize={mySize} />
       </div>

--- a/app/user/mysize/page.tsx
+++ b/app/user/mysize/page.tsx
@@ -1,3 +1,4 @@
+import MobileSection from '@/components/MobileSection';
 import EditButton from '@/components/MyPage/MySize/EditButton';
 import MySizeInfo from '@/components/MyPage/MySize/MySizeInfo';
 import React from 'react';
@@ -9,7 +10,11 @@ type Props = {};
 function MySizePage(props: Props) {
   return (
     <>
-      <MyPageSection sectionName="내 맞춤 정보 설정" />
+      <MyPageSection
+        sectionName="내 맞춤 정보 설정"
+        displayStyle="hidden md:block"
+      />
+      <MobileSection sectionName="내 맞춤 정보 설정" />
       <div className="flex flex-col gap-8 md:gap-12 w-full md:flex-row">
         <GuidelinePic />
         {/* @ts-expect-error Server Component */}

--- a/app/user/mysize/page.tsx
+++ b/app/user/mysize/page.tsx
@@ -1,3 +1,4 @@
+import EditButton from '@/components/MyPage/MySize/EditButton';
 import MySizeInfo from '@/components/MyPage/MySize/MySizeInfo';
 import React from 'react';
 import MyPageSection from '../../../components/MyPage/MyPageSection';
@@ -9,11 +10,12 @@ function MySizePage(props: Props) {
   return (
     <>
       <MyPageSection sectionName="내 맞춤 정보 설정" />
-      <div className="flex flex-col gap-8 md:gap-4 w-full md:flex-row">
+      <div className="flex flex-col gap-8 md:gap-12 w-full md:flex-row">
         <GuidelinePic />
         {/* @ts-expect-error Server Component */}
         <MySizeInfo />
       </div>
+      <EditButton />
     </>
   );
 }

--- a/app/user/mysize/page.tsx
+++ b/app/user/mysize/page.tsx
@@ -1,9 +1,21 @@
+import MySizeInfo from '@/components/MyPage/MySize/MySizeInfo';
 import React from 'react';
+import MyPageSection from '../../../components/MyPage/MyPageSection';
+import GuidelinePic from '../../../components/MyPage/MySize/GuidelinePic';
 
 type Props = {};
 
 function MySizePage(props: Props) {
-  return <div>내 맞춤 정보 설정</div>;
+  return (
+    <>
+      <MyPageSection sectionName="내 맞춤 정보 설정" />
+      <div className="flex flex-col gap-8 md:gap-4 w-full md:flex-row">
+        <GuidelinePic />
+        {/* @ts-expect-error Server Component */}
+        <MySizeInfo />
+      </div>
+    </>
+  );
 }
 
 export default MySizePage;

--- a/app/user/mysize/page.tsx
+++ b/app/user/mysize/page.tsx
@@ -15,7 +15,7 @@ function MySizePage(props: Props) {
         displayStyle="hidden md:block"
       />
       <MobileSection sectionName="내 맞춤 정보 설정" />
-      <div className="flex flex-col gap-8 md:gap-12 w-full md:flex-row">
+      <div className="flex flex-col gap-8 md:gap-12 w-full md:flex-row md:portrait:flex-col">
         <GuidelinePic />
         {/* @ts-expect-error Server Component */}
         <MySizeInfo />

--- a/app/user/mysize/smart_analysis/page.tsx
+++ b/app/user/mysize/smart_analysis/page.tsx
@@ -1,3 +1,4 @@
+import MobileSection from '@/components/MobileSection';
 import Guideline from '@/components/MyPage/MySize/Guideline';
 import SmartAnalysisPhotoSubmitForm from '@/components/MyPage/MySize/SmartAnalysisPhotoSubmitForm';
 import React from 'react';
@@ -9,7 +10,11 @@ type Props = {};
 function SmartAnalysisPage(props: Props) {
   return (
     <>
-      <MyPageSection sectionName="내 맞춤 정보 설정" />
+      <MyPageSection
+        sectionName="내 맞춤 정보 설정"
+        displayStyle="hidden md:block"
+      />
+      <MobileSection sectionName="내 맞춤 정보 설정" />
       <Section sectionName="스마트 분석" />
       <div className="flex flex-col md:flex-row gap-4 mt-2">
         <SmartAnalysisPhotoSubmitForm photoType="FRONT" />

--- a/app/user/mysize/smart_analysis/page.tsx
+++ b/app/user/mysize/smart_analysis/page.tsx
@@ -1,9 +1,23 @@
+import Guideline from '@/components/MyPage/MySize/Guideline';
+import SmartAnalysisPhotoSubmitForm from '@/components/MyPage/MySize/SmartAnalysisPhotoSubmitForm';
 import React from 'react';
+import MyPageSection from '../../../../components/MyPage/MyPageSection';
+import Section from '../../../../components/Section';
 
 type Props = {};
 
 function SmartAnalysisPage(props: Props) {
-  return <div>스마트분석</div>;
+  return (
+    <>
+      <MyPageSection sectionName="내 맞춤 정보 설정" />
+      <Section sectionName="스마트 분석" />
+      <div className="flex flex-col md:flex-row gap-4 mt-2">
+        <SmartAnalysisPhotoSubmitForm photoType="FRONT" />
+        <SmartAnalysisPhotoSubmitForm photoType="SIDE" />
+      </div>
+      <Guideline />
+    </>
+  );
 }
 
 export default SmartAnalysisPage;

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -11,7 +11,7 @@ function MyPage(props: Props) {
       <MyPageCommon />
       <MyPageSection sectionName="최근 본 상품" />
       <MyPageSection sectionName="좋아요한 상품" />
-      <div className="pt-6 border-t border-nav-black text-center md:text-right">
+      <div className="pt-6 border-t-[1.5px] border-nav-black text-center md:text-right">
         <Link
           className="md:text-right text-custom-gray-800 font-bold underline decoration-custom-gray-800"
           href="/user/delete"

--- a/components/MobileSection.tsx
+++ b/components/MobileSection.tsx
@@ -1,0 +1,15 @@
+import Image from 'next/image';
+import back from 'public/icon/left_black.svg';
+
+type Props = {
+  sectionName: string;
+};
+
+export default function MobileSection({ sectionName }: Props) {
+  return (
+    <div className="relative py-6 text-center text-lg md:hidden">
+      <Image className="absolute left-0 inline-block" src={back} alt="<" />
+      <span className="inline-block font-bold">{sectionName}</span>
+    </div>
+  );
+}

--- a/components/MyPage/MyPageSection.tsx
+++ b/components/MyPage/MyPageSection.tsx
@@ -1,10 +1,11 @@
 type Props = {
   sectionName: '최근 본 상품' | '좋아요한 상품' | '내 맞춤 정보 설정';
+  displayStyle: string;
 };
 
-export default function MyPageSection({ sectionName }: Props) {
+export default function MyPageSection({ sectionName, displayStyle }: Props) {
   return (
-    <div className="my-8 pb-2 border-b-[1.5px] border-nav-black">
+    <div className={`my-8 pb-2 border-b-[1.5px] border-nav-black ${displayStyle}`}>
       <span className="font-bold text-lg">{sectionName}</span>
     </div>
   );

--- a/components/MyPage/MyPageSection.tsx
+++ b/components/MyPage/MyPageSection.tsx
@@ -4,8 +4,8 @@ type Props = {
 
 export default function MyPageSection({ sectionName }: Props) {
   return (
-    <div className="my-8 pb-2 border-b border-nav-black">
-      <span className="font-bold">{sectionName}</span>
+    <div className="my-8 pb-2 border-b-[1.5px] border-nav-black">
+      <span className="font-bold text-lg">{sectionName}</span>
     </div>
   );
 }

--- a/components/MyPage/MySize/EditButton.tsx
+++ b/components/MyPage/MySize/EditButton.tsx
@@ -1,0 +1,23 @@
+'use client';
+import { useState } from 'react';
+import Modal from './Modal';
+
+export default function EditButton() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    setIsModalOpen(true);
+  };
+
+  return (
+    <>
+      <button
+        className="w-full md:w-[10rem] mt-8 md:mt-12 py-2 block mx-auto bg-main-color text-white rounded-lg"
+        onClick={handleClick}
+      >
+        수정
+      </button>
+      {isModalOpen ? <Modal setIsModalOpen={setIsModalOpen} /> : null}
+    </>
+  );
+}

--- a/components/MyPage/MySize/EditForm.tsx
+++ b/components/MyPage/MySize/EditForm.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { MySize } from '@/service/mysize';
+import EditFormInput from './EditFormInput';
+
+type Props = {
+  mySize: MySize;
+};
+
+export default function EditForm({ mySize }: Props) {
+  return (
+    <div className="flex-1 w-full h-full">
+      <div className="font-semibold pb-6">열졍콩님의 체형</div>
+
+      <div className="flex flex-col md:flex-row md:gap-12">
+        <div className="flex-1">
+          <EditFormInput bodyType="height" size={mySize.height} />
+          <EditFormInput bodyType="weight" size={mySize.weight} />
+          <EditFormInput bodyType="arm" size={mySize.arm} />
+          <EditFormInput bodyType="leg" size={mySize.leg} />
+          <EditFormInput bodyType="shoulder" size={mySize.shoulder} />
+        </div>
+
+        <div className="flex-1">
+          <EditFormInput bodyType="chest" size={mySize.chest} />
+          <EditFormInput bodyType="waist" size={mySize.waist} />
+          <EditFormInput bodyType="thigh" size={mySize.thigh} />
+          <EditFormInput bodyType="hip" size={mySize.hip} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/MyPage/MySize/EditFormInput.tsx
+++ b/components/MyPage/MySize/EditFormInput.tsx
@@ -1,0 +1,49 @@
+type Props = {
+  bodyType:
+    | 'height'
+    | 'weight'
+    | 'arm'
+    | 'leg'
+    | 'shoulder'
+    | 'waist'
+    | 'chest'
+    | 'thigh'
+    | 'hip';
+  size: number | null;
+};
+
+const bodyTypeEn2Ko = {
+  height: '키',
+  weight: '몸무게',
+  arm: '팔 길이',
+  leg: '다리 길이',
+  shoulder: '어깨 너비',
+  waist: '허리 둘레',
+  chest: '가슴 둘레',
+  thigh: '허벅지 둘레',
+  hip: '엉덩이 둘레',
+};
+
+export default function EditFormInput({ bodyType, size }: Props) {
+  return (
+    <div className="w-full relative h-8 md:h-16">
+      <label>
+        {bodyType === 'height' || bodyType === 'weight' ? (
+          <span className="text-main-color absolute left-[-0.75rem]">* </span>
+        ) : null}
+        {bodyTypeEn2Ko[bodyType]}
+      </label>
+      <input
+        className="absolute right-8 w-[25%] md:w-[30%] lg:w-[40%] landscape:w-[35%] lg:landscape:w-[40%]  border bg-transparent text-right px-2"
+        type="number"
+        inputMode="numeric"
+        placeholder={size !== null ? size.toString() : ''}
+        min={0}
+        max={300}
+      />
+      <span className="absolute right-0">
+        {bodyType === 'weight' ? 'kg' : 'cm'}
+      </span>
+    </div>
+  );
+}

--- a/components/MyPage/MySize/Guideline.tsx
+++ b/components/MyPage/MySize/Guideline.tsx
@@ -1,0 +1,12 @@
+const guidelineStyle = 'block py-1';
+
+export default function Guideline() {
+  return (
+    <div>
+      <h3 className="mt-8 mb-2 font-semibold">사진 가이드라인</h3>
+      <span className={guidelineStyle}>‧ 가이드라인 설명 1</span>
+      <span className={guidelineStyle}>‧ 가이드라인 설명 2</span>
+      <span className={guidelineStyle}>‧ 가이드라인 설명 3</span>
+    </div>
+  );
+}

--- a/components/MyPage/MySize/GuidelinePic.tsx
+++ b/components/MyPage/MySize/GuidelinePic.tsx
@@ -1,0 +1,18 @@
+import Image from 'next/image';
+import guideline1 from 'public/Fittering_logo.png';
+import guideline2 from 'public/Fittering_logo.png';
+
+const guidelinePicStyle =
+  'w-auto h-full border rounded-lg overflow-hidden object-contain';
+
+export default function GuidelinePic() {
+  return (
+    <div className="flex-1 flex flex-col w-full">
+      <div className="font-semibold pb-6">가이드라인 사진 예시</div>
+      <div className="flex gap-4 w-full h-72 md:h-96 items-center justify-center">
+        <Image className={guidelinePicStyle} src={guideline1} alt="" />
+        <Image className={guidelinePicStyle} src={guideline2} alt="" />
+      </div>
+    </div>
+  );
+}

--- a/components/MyPage/MySize/GuidelinePic.tsx
+++ b/components/MyPage/MySize/GuidelinePic.tsx
@@ -9,7 +9,7 @@ export default function GuidelinePic() {
   return (
     <div className="flex-1 flex flex-col w-full">
       <div className="font-semibold pb-6">가이드라인 사진 예시</div>
-      <div className="flex gap-4 w-full h-72 md:h-96 items-center justify-center">
+      <div className="flex gap-4 w-full h-72 md:h-[22rem] items-center justify-center">
         <Image className={guidelinePicStyle} src={guideline1} alt="" />
         <Image className={guidelinePicStyle} src={guideline2} alt="" />
       </div>

--- a/components/MyPage/MySize/Modal.tsx
+++ b/components/MyPage/MySize/Modal.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import Link from 'next/link';
+import Image from 'next/image';
+import pencil from '/public/icon/pencil_white.svg';
+import bulb from 'public/icon/light_bulb_white.svg';
+import x from 'public/icon/x_black.svg';
+import ModalBackground from './ModalBackground';
+import { useState, useEffect } from 'react';
+import { detectMobileDevice } from '../../../utils/detectMobileDevice';
+
+type Props = {
+  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export default function Modal({ setIsModalOpen }: Props) {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    setIsMobile(detectMobileDevice(window.navigator.userAgent));
+  }, []);
+
+  return (
+    <>
+      <ModalBackground setIsModalOpen={setIsModalOpen} />
+      <div
+        className={
+          'fixed top-[11rem] left-0 right-0 mx-auto bg-white border w-[90vw] h-[63vw] xs:w-[80vw] xs:h-[52vw] md:w-[40vw] md:h-[28vw] text-center z-10 rounded-md ' +
+          (isMobile
+            ? 'landscape:top-[50%] landscape:translate-y-[-50%] landscape:w-[128vh] landscape:h-[90vh]'
+            : '')
+        }
+      >
+        <span
+          className={
+            'block my-[4.5vw] xs:my-[3.5vw] md:my-[2.5vw] font-semibold text-sm md:text-base ' +
+            (isMobile ? 'landscape:xs:my-[4vw]' : '')
+          }
+        >
+          입력 방식 선택하기
+        </span>
+        <Image
+          onClick={() => setIsModalOpen(false)}
+          className="absolute top-3 right-3 cursor-pointer"
+          src={x}
+          alt="x"
+        />
+        <div className="flex gap-2 xs:gap-4 items-center justify-center">
+          <Link
+            className={
+              'flex flex-col items-center justify-center rounded-md w-[32vw] h-[32vw] md:w-[16vw] md:h-[16vw] text-white font-semibold text-xs xs:text-sm md:text-lg bg-main-color ' +
+              (isMobile ? 'landscape:w-[56vh] landscape:h-[56vh]' : '')
+            }
+            href="/user/mysize/edit"
+          >
+            <Image className="mx-auto w-5/12 mb-3" src={pencil} alt="" />
+            직접 입력하기
+          </Link>
+          <Link
+            className={
+              'flex flex-col items-center justify-center rounded-md w-[32vw] h-[32vw] md:w-[16vw] md:h-[16vw] text-white font-semibold text-xs xs:text-sm md:text-lg bg-bean-color ' +
+              (isMobile ? 'landscape:w-[56vh] landscape:h-[56vh]' : '')
+            }
+            href="/user/mysize/smart_analysis"
+          >
+            <Image className="mx-auto w-5/12 mb-3" src={bulb} alt="" />
+            스마트 분석
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/MyPage/MySize/ModalBackground.tsx
+++ b/components/MyPage/MySize/ModalBackground.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+type Props = {
+  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export default function ModalBackground({ setIsModalOpen }: Props) {
+  const handleBackgroundClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    setIsModalOpen(false);
+  };
+  return (
+    <div
+      onClick={handleBackgroundClick}
+      className="w-screen h-screen fixed left-0 top-0 bg-[#6e6e6e] opacity-50 z-0"
+    ></div>
+  );
+}

--- a/components/MyPage/MySize/MySizeInfo.tsx
+++ b/components/MyPage/MySize/MySizeInfo.tsx
@@ -1,0 +1,107 @@
+import { getMySize } from '@/service/mysize';
+
+const tableStyle =
+  'table-fixed w-full h-1/2 md:w-1/2 md:h-full md:border-spacing-y-8 md:align-top';
+const trStyle = 'h-8 md:h-16';
+const sizeStyle = 'text-main-color font-semibold text-lg pr-2';
+
+export default async function MySizeInfo() {
+  const mySize = await getMySize();
+
+  return (
+    <div className="flex-1 w-full h-full">
+      <div className="font-semibold pb-6">열졍콩님의 체형</div>
+      <div className="flex flex-col md:flex-row md:gap-12">
+        <table className={tableStyle}>
+          <tbody>
+            <tr className={trStyle}>
+              <td className="text-left align-top">‧ 키</td>
+              <td className="text-right align-top">
+                <span className={sizeStyle}>
+                  {mySize.height !== null ? mySize.height : '-'}
+                </span>
+                cm
+              </td>
+            </tr>
+            <tr className={trStyle}>
+              <td className="text-left align-top">‧ 몸무게</td>
+              <td className="text-right align-top">
+                <span className={sizeStyle}>
+                  {mySize.weight !== null ? mySize.weight : '-'}
+                </span>
+                kg
+              </td>
+            </tr>
+            <tr className={trStyle}>
+              <td className="text-left align-top">‧ 팔 길이</td>
+              <td className="text-right align-top">
+                <span className={sizeStyle}>
+                  {mySize.arm !== null ? mySize.arm : '-'}
+                </span>
+                cm
+              </td>
+            </tr>
+            <tr className={trStyle}>
+              <td className="text-left align-top">‧ 다리 길이</td>
+              <td className="text-right align-top">
+                <span className={sizeStyle}>
+                  {mySize.leg !== null ? mySize.leg : '-'}
+                </span>
+                cm
+              </td>
+            </tr>
+            <tr className={trStyle}>
+              <td className="text-left align-top">‧ 어깨 너비</td>
+              <td className="text-right align-top">
+                <span className={sizeStyle}>
+                  {mySize.shoulder !== null ? mySize.shoulder : '-'}
+                </span>
+                cm
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <table className={tableStyle}>
+          <tbody>
+            <tr className={trStyle}>
+              <td className="text-left align-top">‧ 가슴 둘레</td>
+              <td className="text-right align-top">
+                <span className={sizeStyle}>
+                  {mySize.chest !== null ? mySize.chest : '-'}
+                </span>
+                cm
+              </td>
+            </tr>
+            <tr className={trStyle}>
+              <td className="text-left align-top">‧ 허리 둘레</td>
+              <td className="text-right align-top">
+                <span className={sizeStyle}>
+                  {mySize.waist !== null ? mySize.waist : '-'}
+                </span>
+                cm
+              </td>
+            </tr>
+            <tr className={trStyle}>
+              <td className="text-left align-top">‧ 허벅지 둘레</td>
+              <td className="text-right align-top">
+                <span className={sizeStyle}>
+                  {mySize.thigh !== null ? mySize.thigh : '-'}
+                </span>
+                cm
+              </td>
+            </tr>
+            <tr className={trStyle}>
+              <td className="text-left align-top">‧ 엉덩이 둘레</td>
+              <td className="text-right align-top">
+                <span className={sizeStyle}>
+                  {mySize.hip !== null ? mySize.hip : '-'}
+                </span>
+                cm
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/components/MyPage/MySize/SmartAnalysisPhotoSubmitForm.tsx
+++ b/components/MyPage/MySize/SmartAnalysisPhotoSubmitForm.tsx
@@ -1,0 +1,19 @@
+import Image from 'next/image';
+import plus from 'public/icon/plus_white.svg';
+
+type Props = {
+  photoType: 'FRONT' | 'SIDE';
+};
+
+export default function SmartAnalysisPhotoSubmitForm({ photoType }: Props) {
+  return (
+    <div className="flex flex-col gap-4 items-center justify-center border rounded-lg w-full h-[54vh] text-center">
+      <button className="bg-main-color text-white text-[3rem] rounded-full w-16 h-16">
+        <Image className="mx-auto" src={plus} alt="+" />
+      </button>
+      <span className="text-main-color">
+        {photoType === 'FRONT' ? '정면' : '측면'} 사진 등록
+      </span>
+    </div>
+  );
+}

--- a/components/MyPage/UserEditLinks.tsx
+++ b/components/MyPage/UserEditLinks.tsx
@@ -13,7 +13,7 @@ export default function UserEditLinks() {
         <Image className="inline-block w-4 h-4 mr-3" src={pencil} alt="" />
         회원정보 수정
       </Link>
-      <Link className={`${linkStyle} bg-button-black`} href="/user/mysize/edit">
+      <Link className={`${linkStyle} bg-button-black`} href="/user/mysize">
         <Image className="inline-block w-4 h-4 mr-3" src={ruler} alt="" /> 내
         맞춤 정보 설정
       </Link>

--- a/data/mysize.json
+++ b/data/mysize.json
@@ -1,0 +1,11 @@
+{
+  "height": 200,
+  "weight": 100,
+  "arm": null,
+  "leg": null,
+  "shoulder": null,
+  "waist": null,
+  "chest": null,
+  "thigh": null,
+  "hip": null
+}

--- a/public/icon/plus_white.svg
+++ b/public/icon/plus_white.svg
@@ -1,0 +1,4 @@
+<svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.0781 1L13.0781 25" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<path d="M25 13.0771L1 13.0771" stroke="white" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/service/mysize.ts
+++ b/service/mysize.ts
@@ -1,0 +1,20 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+
+export type MySize = {
+  height: number | null;
+  weight: number | null;
+  arm: number | null;
+  leg: number | null;
+  shoulder: number | null;
+  waist: number | null;
+  chest: number | null;
+  thigh: number | null;
+  hip: number | null;
+};
+
+export async function getMySize(): Promise<MySize> {
+  // 더미 데이터 읽어옴
+  const filePath = path.join(process.cwd(), 'data', 'mysize.json');
+  return readFile(filePath, 'utf-8').then<MySize>(JSON.parse);
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,8 +24,9 @@ module.exports = {
         'button-black': '#333333',
       },
       screens: {
-        'xs': '350px',
-      }
+        xs: '350px',
+        md: '769px',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 내 맞춤 정보 설정(/user/mysize/*) 관련 UI 추가 + 스타일링 & 반응형 적용

- 내 체형 정보 조회
- 맞춤 정보 입력 방식 선택 모달창
- 스마트 분석 사진 등록
- 내 체형 정보 직접 입력하기

## 기타
- 내 체형 정보 직접 입력하기 페이지 개발 중에 number type input에서 화살표가 보이지 않도록 전역으로 설정함
  - [chore: number type input 화살표 제거 전역 설정](https://github.com/YeolJyeongKong/fittering-FE/commit/ef2cae94bae3bdb8c5c4b1764fb223680fa0ab88)
- 모바일에서 현재 메뉴 표시하는 section에 뒤로 가기 버튼 나타나도록 반응형 수정
  - [feat: 현재 메뉴 section 반응형 추가](https://github.com/YeolJyeongKong/fittering-FE/commit/f50ec63f55b1f48cea11da3efbeb499b27ca0963)

### [관련 포스팅](https://velog.io/@thumbzzero/Fittering-%EA%B0%9C%EB%B0%9C-%EA%B8%B0%EB%A1%9D-%EB%82%B4-%EB%A7%9E%EC%B6%A4-%EC%A0%95%EB%B3%B4-%EC%84%A4%EC%A0%95-UI-%EC%9E%91%EC%97%85)
