### PR TITLE
카테고리 Navbar 추가 & 관련 Bug Fix

### DIFF
--- a/app/categories/[[...categoryName]]/page.tsx
+++ b/app/categories/[[...categoryName]]/page.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+type Props = {
+  params: {
+    categoryName?: string[];
+  };
+};
+
+function CategoryPage({ params: { categoryName } }: Props) {
+  return (
+    <div>
+      {categoryName === undefined
+        ? '전체 '
+        : categoryName.map((category) => `${category} `)}
+      카테고리 조회
+    </div>
+  );
+}
+
+export default CategoryPage;

--- a/app/categories/[category_id]/page.tsx
+++ b/app/categories/[category_id]/page.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-
-type Props = {};
-
-function CategoryPage(props: Props) {
-  return <div>특정 카테고리 자세히 보기</div>;
-}
-
-export default CategoryPage;

--- a/app/categories/layout.tsx
+++ b/app/categories/layout.tsx
@@ -1,0 +1,14 @@
+import MainCategoryNavbar from '@/components/Navbar/MainCategoryNavbar';
+
+export default function CategoryLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <MainCategoryNavbar />
+      {children}
+    </>
+  );
+}

--- a/app/categories/layout.tsx
+++ b/app/categories/layout.tsx
@@ -1,4 +1,5 @@
 import MainCategoryNavbar from '@/components/Navbar/MainCategoryNavbar';
+import SubCategoryNavbar from '@/components/Navbar/SubCategoryNavbar';
 
 export default function CategoryLayout({
   children,
@@ -8,6 +9,7 @@ export default function CategoryLayout({
   return (
     <>
       <MainCategoryNavbar />
+      <SubCategoryNavbar />
       {children}
     </>
   );

--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-
-type Props = {};
-
-function CategoriesPage(props: Props) {
-  return <div>카테고리 전체 조회</div>;
-}
-
-export default CategoriesPage;

--- a/components/GlobalFilter.tsx
+++ b/components/GlobalFilter.tsx
@@ -1,11 +1,16 @@
 'use client';
+
 import { useState, useEffect } from 'react';
 import { detectMobileDevice } from '../utils/detectMobileDevice';
 
 const buttonStyle = ' w-8 h-8 text-xs md:w-12 md:h-12 md:text-sm font-semibold';
 
 export default function GlobalFilter() {
-  const [selectedFilter, setSelectedFilter] = useState('A');
+  const [selectedFilter, setSelectedFilter] = useState(
+    localStorage.getItem('GLOBAL_FILTER') === null
+      ? 'A'
+      : localStorage.getItem('GLOBAL_FILTER')
+  );
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {

--- a/components/Navbar/MainCategoryLink.tsx
+++ b/components/Navbar/MainCategoryLink.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+
+type Props = {
+  key: number;
+  href: string;
+  isSelected: boolean;
+  name: string;
+};
+
+export default function MainCategoryLink({
+  key,
+  href,
+  isSelected,
+  name,
+}: Props) {
+  return (
+    <Link
+      key={key}
+      href={href}
+      className={
+        'flex-1 text-center pb-2 font-semibold border-b ' +
+        (isSelected
+          ? 'border-main-color border-b-[2px] text-black'
+          : 'text-custom-gray-800')
+      }
+    >
+      {name}
+    </Link>
+  );
+}

--- a/components/Navbar/MainCategoryLink.tsx
+++ b/components/Navbar/MainCategoryLink.tsx
@@ -1,21 +1,18 @@
 import Link from 'next/link';
 
 type Props = {
-  key: number;
   href: string;
   isSelected: boolean;
   name: string;
 };
 
 export default function MainCategoryLink({
-  key,
   href,
   isSelected,
   name,
 }: Props) {
   return (
     <Link
-      key={key}
       href={href}
       className={
         'flex-1 text-center pb-2 font-semibold border-b ' +

--- a/components/Navbar/MainCategoryNavbar.tsx
+++ b/components/Navbar/MainCategoryNavbar.tsx
@@ -5,7 +5,9 @@ import { usePathname } from 'next/navigation';
 import MainCategoryLink from './MainCategoryLink';
 
 export default function MainCategoryNavbar() {
-  const categories: Category[] = [outer, top, bottom, dress];
+  const gender = localStorage.getItem('GLOBAL_FILTER');
+  const categories: Category[] =
+    gender === 'M' ? [outer, top, bottom] : [outer, top, bottom, dress];
   const pathname = usePathname();
 
   return (

--- a/components/Navbar/MainCategoryNavbar.tsx
+++ b/components/Navbar/MainCategoryNavbar.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { category, outer, top, dress, bottom } from '@/types/categories';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+/*
+카테고리 조회 페이지 헤더 아래에 대분류 Navbar / 소분류 Navbar 추가 & 스타일링
+소분류 Navbar는 상의, 아우터, 바지에만 존재 (전체 / 원피스는 소분류 없음)
+각 카테고리 선택 시 해당 카테고리로 라우팅 되도록 Link 추가
+*/
+
+export default function MainCategoryNavbar() {
+  const categories: category[] = [outer, top, dress, bottom];
+  const pathname = usePathname();
+
+  return (
+    <div className="w-full mt-4 md:mt-8 text-sm md:text-base flex items-center justify-center">
+      <Link
+        href="/categories"
+        className={
+          'flex-1 text-center pb-2 font-semibold border-b ' +
+          (pathname === '/categories'
+            ? 'border-main-color border-b-[2px] text-black'
+            : 'text-custom-gray-800')
+        }
+      >
+        전체
+      </Link>
+      {categories.map((category) => (
+        <Link
+          key={category.index}
+          href={category.url}
+          className={
+            'flex-1 text-center pb-2 font-semibold border-b ' +
+            (pathname.includes(category.url)
+              ? 'border-main-color border-b-[2px] text-black'
+              : 'text-custom-gray-800')
+          }
+        >
+          {category.name}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/components/Navbar/MainCategoryNavbar.tsx
+++ b/components/Navbar/MainCategoryNavbar.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { category, outer, top, dress, bottom } from '@/types/categories';
+import { category, outer, top, bottom, dress } from '@/types/categories';
 import { usePathname } from 'next/navigation';
 import MainCategoryLink from './MainCategoryLink';
 
 export default function MainCategoryNavbar() {
-  const categories: category[] = [outer, top, dress, bottom];
+  const categories: category[] = [outer, top, bottom, dress];
   const pathname = usePathname();
 
   return (

--- a/components/Navbar/MainCategoryNavbar.tsx
+++ b/components/Navbar/MainCategoryNavbar.tsx
@@ -11,7 +11,6 @@ export default function MainCategoryNavbar() {
   return (
     <div className="w-full mt-4 md:mt-8 text-sm md:text-base flex items-center justify-center">
       <MainCategoryLink
-        key={-1}
         href="/categories"
         isSelected={pathname === '/categories'}
         name="전체"

--- a/components/Navbar/MainCategoryNavbar.tsx
+++ b/components/Navbar/MainCategoryNavbar.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { category, outer, top, bottom, dress } from '@/types/categories';
+import { Category, outer, top, bottom, dress } from '@/types/categories';
 import { usePathname } from 'next/navigation';
 import MainCategoryLink from './MainCategoryLink';
 
 export default function MainCategoryNavbar() {
-  const categories: category[] = [outer, top, bottom, dress];
+  const categories: Category[] = [outer, top, bottom, dress];
   const pathname = usePathname();
 
   return (

--- a/components/Navbar/MainCategoryNavbar.tsx
+++ b/components/Navbar/MainCategoryNavbar.tsx
@@ -1,14 +1,8 @@
 'use client';
 
 import { category, outer, top, dress, bottom } from '@/types/categories';
-import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-
-/*
-카테고리 조회 페이지 헤더 아래에 대분류 Navbar / 소분류 Navbar 추가 & 스타일링
-소분류 Navbar는 상의, 아우터, 바지에만 존재 (전체 / 원피스는 소분류 없음)
-각 카테고리 선택 시 해당 카테고리로 라우팅 되도록 Link 추가
-*/
+import MainCategoryLink from './MainCategoryLink';
 
 export default function MainCategoryNavbar() {
   const categories: category[] = [outer, top, dress, bottom];
@@ -16,30 +10,19 @@ export default function MainCategoryNavbar() {
 
   return (
     <div className="w-full mt-4 md:mt-8 text-sm md:text-base flex items-center justify-center">
-      <Link
+      <MainCategoryLink
+        key={-1}
         href="/categories"
-        className={
-          'flex-1 text-center pb-2 font-semibold border-b ' +
-          (pathname === '/categories'
-            ? 'border-main-color border-b-[2px] text-black'
-            : 'text-custom-gray-800')
-        }
-      >
-        전체
-      </Link>
+        isSelected={pathname === '/categories'}
+        name="전체"
+      />
       {categories.map((category) => (
-        <Link
+        <MainCategoryLink
           key={category.index}
           href={category.url}
-          className={
-            'flex-1 text-center pb-2 font-semibold border-b ' +
-            (pathname.includes(category.url)
-              ? 'border-main-color border-b-[2px] text-black'
-              : 'text-custom-gray-800')
-          }
-        >
-          {category.name}
-        </Link>
+          isSelected={pathname.includes(category.url)}
+          name={category.name}
+        />
       ))}
     </div>
   );

--- a/components/Navbar/SubCategoryLink.tsx
+++ b/components/Navbar/SubCategoryLink.tsx
@@ -7,6 +7,9 @@ type Props = {
 };
 
 export default function SubCategoryLink({ href, isSelected, name }: Props) {
+  const gender = localStorage.getItem('GLOBAL_FILTER');
+  if (gender === 'M' && href.includes('/skirt')) return null;
+
   return (
     <Link
       href={href}

--- a/components/Navbar/SubCategoryLink.tsx
+++ b/components/Navbar/SubCategoryLink.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+
+type Props = {
+  href: string;
+  isSelected: boolean;
+  name: string;
+};
+
+export default function SubCategoryLink({ href, isSelected, name }: Props) {
+  return (
+    <Link
+      href={href}
+      className={
+        isSelected ? 'font-semibold text-main-color' : 'text-custom-gray-800'
+      }
+    >
+      {name}
+    </Link>
+  );
+}

--- a/components/Navbar/SubCategoryNavbar.tsx
+++ b/components/Navbar/SubCategoryNavbar.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Category, outer, top, dress, bottom } from '@/types/categories';
+import { usePathname } from 'next/navigation';
+import SubCategoryLink from './SubCategoryLink';
+
+export default function SubCategoryNavbar() {
+  const pathname = usePathname();
+  let mainCategory: Category;
+
+  if (pathname === '/categories' || pathname.includes(dress.url)) {
+    return null;
+  }
+
+  if (pathname.includes(outer.url)) mainCategory = outer;
+  else if (pathname.includes(top.url)) mainCategory = top;
+  else mainCategory = bottom;
+
+  return (
+    <div className="flex items-center justify-center gap-2 xs:gap-6 mt-4 text-xs md:text-sm">
+      <SubCategoryLink
+        href={mainCategory.url}
+        isSelected={pathname === mainCategory.url}
+        name="전체"
+      />
+      {mainCategory.sub.map((sub) => (
+        <SubCategoryLink
+          key={sub.index}
+          href={sub.url}
+          isSelected={pathname === sub.url}
+          name={sub.name}
+        />
+      ))}
+    </div>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,7 +24,7 @@ module.exports = {
         'button-black': '#333333',
       },
       screens: {
-        xs: '350px',
+        xs: '356px',
         md: '769px',
       },
     },

--- a/types/categories.ts
+++ b/types/categories.ts
@@ -1,0 +1,91 @@
+export type category = typeof outer | typeof top | typeof dress | typeof bottom;
+
+export const outer = {
+  index: 0,
+  name: '아우터',
+  url: '/categories/outer' as const,
+  sub: [
+    {
+      index: 0,
+      name: '후드 집업',
+      url: '/categories/outer/hood',
+    },
+    {
+      index: 1,
+      name: '코트',
+      url: '/categories/outer/coat',
+    },
+    {
+      index: 2,
+      name: '가디건',
+      url: '/categories/outer/cardigan',
+    },
+    {
+      index: 3,
+      name: '패딩',
+      url: '/categories/outer/padded_jacket',
+    },
+    {
+      index: 4,
+      name: '자켓',
+      url: '/categories/outer/jacket',
+    },
+    {
+      index: 5,
+      name: '기타',
+      url: '/categories/outer/others',
+    },
+  ],
+};
+
+export const top = {
+  index: 1,
+  name: '상의',
+  url: '/categories/top' as const,
+  sub: [
+    {
+      index: 6,
+      name: '셔츠/블라우스',
+      url: '/categories/top/shirt',
+    },
+    {
+      index: 7,
+      name: '니트',
+      url: '/categories/top/knit',
+    },
+    {
+      index: 8,
+      name: '티셔츠',
+      url: '/categories/top/t-shirt',
+    },
+    {
+      index: 9,
+      name: '맨투맨/후드티',
+      url: '/categories/top/sweatshirt-hood',
+    },
+  ],
+};
+
+export const dress = {
+  index: 3,
+  name: '원피스',
+  url: '/categories/dress' as const,
+};
+
+export const bottom = {
+  index: 3,
+  name: '하의',
+  url: '/categories/bottom' as const,
+  sub: [
+    {
+      index: 10,
+      name: '바지',
+      url: '/categories/bottom/pants',
+    },
+    {
+      index: 11,
+      name: '치마',
+      url: '/categories/bottom/skirt',
+    },
+  ],
+};

--- a/types/categories.ts
+++ b/types/categories.ts
@@ -16,32 +16,32 @@ export const outer: Category = {
   url: '/categories/outer',
   sub: [
     {
-      index: 0,
+      index: 1,
       name: '후드 집업',
       url: '/categories/outer/hood',
     },
     {
-      index: 1,
+      index: 2,
       name: '코트',
       url: '/categories/outer/coat',
     },
     {
-      index: 2,
+      index: 3,
       name: '가디건',
       url: '/categories/outer/cardigan',
     },
     {
-      index: 3,
+      index: 4,
       name: '패딩',
       url: '/categories/outer/padded_jacket',
     },
     {
-      index: 4,
+      index: 5,
       name: '자켓',
       url: '/categories/outer/jacket',
     },
     {
-      index: 5,
+      index: 6,
       name: '기타',
       url: '/categories/outer/others',
     },
@@ -54,22 +54,22 @@ export const top: Category = {
   url: '/categories/top',
   sub: [
     {
-      index: 6,
+      index: 7,
       name: '셔츠/블라우스',
       url: '/categories/top/shirt',
     },
     {
-      index: 7,
+      index: 8,
       name: '니트',
       url: '/categories/top/knit',
     },
     {
-      index: 8,
+      index: 9,
       name: '티셔츠',
       url: '/categories/top/t-shirt',
     },
     {
-      index: 9,
+      index: 10,
       name: '맨투맨/후드티',
       url: '/categories/top/sweatshirt-hood',
     },
@@ -89,12 +89,12 @@ export const bottom: Category = {
   url: '/categories/bottom',
   sub: [
     {
-      index: 10,
+      index: 11,
       name: '바지',
       url: '/categories/bottom/pants',
     },
     {
-      index: 11,
+      index: 12,
       name: '치마',
       url: '/categories/bottom/skirt',
     },

--- a/types/categories.ts
+++ b/types/categories.ts
@@ -1,9 +1,19 @@
-export type category = typeof outer | typeof top | typeof dress | typeof bottom;
+export type Category = {
+  index: number;
+  name: string;
+  url: string;
+  sub:
+    | {
+        index: number;
+        name: string;
+        url: string;
+      }[];
+};
 
-export const outer = {
+export const outer: Category = {
   index: 0,
   name: '아우터',
-  url: '/categories/outer' as const,
+  url: '/categories/outer',
   sub: [
     {
       index: 0,
@@ -38,10 +48,10 @@ export const outer = {
   ],
 };
 
-export const top = {
+export const top: Category = {
   index: 1,
   name: '상의',
-  url: '/categories/top' as const,
+  url: '/categories/top',
   sub: [
     {
       index: 6,
@@ -66,16 +76,17 @@ export const top = {
   ],
 };
 
-export const dress = {
-  index: 3,
+export const dress: Category = {
+  index: 2,
   name: '원피스',
-  url: '/categories/dress' as const,
+  url: '/categories/dress',
+  sub: [],
 };
 
-export const bottom = {
+export const bottom: Category = {
   index: 3,
   name: '하의',
-  url: '/categories/bottom' as const,
+  url: '/categories/bottom',
   sub: [
     {
       index: 10,


### PR DESCRIPTION
## 내용
- 카테고리 조회 페이지 헤더 아래에 대분류 Navbar / 소분류 Navbar 추가 & 스타일링
- 소분류 Navbar는 상의, 아우터, 바지에만 존재 (전체 / 원피스는 소분류 없음)
- 각 카테고리 선택 시 해당 카테고리로 라우팅 되도록 `Link` 추가
- 선택된 카테고리에 강조 스타일 추가
- Global Filter에서 선택한 성별이 남성일 경우 원피스와 치마 카테고리가 보이지 않도록 설정
  - [fix: global filter 선택 성별 남성일 때 원피스/치마 카테고리 보이지 않도록 수정](https://github.com/YeolJyeongKong/fittering-FE/commit/c14f59106dbaf93861c3627f64f9ad42eaa8ed70)
  - 해당 기능 구현 중 Global Filter 상태 초깃값이 잘못되어 있는 것을 확인하여 수정함
  - [fix: global filter 잘못된 상태 초깃값 수정](https://github.com/YeolJyeongKong/fittering-FE/commit/d6ac231829c52cbee5308d236cff32ca54479a1f)
- 기존에 전체 카테고리와 특정 카테고리 조회 page.tsx을 별도로 두었으나, 화면 구성이 동일할 예정이므로 폴더명을 `[[...categoryName]]`으로 바꾸어 Dynamic Routes의 파라미터를 [Optional](https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes#optional-catch-all-segments)하게 수정함
  - [fix: 카테고리 dynamic routes 수정](https://github.com/YeolJyeongKong/fittering-FE/commit/3a724ced7eddc33cf484ac00ba576fd8c20629da)

### 카테고리 대분류 - 소분류
- 전체
- 상의(top) - 전체, 셔츠/블라우스(shirt), 니트(knit), 티셔츠(t-shirt), 맨투맨/후드티(sweatshirt-hood)
- 아우터(outer) - 전체, 후드 집업(hood), 코트(coat), 가디건(cardigan), 패딩(padded_jacket), 자켓(jacket), 기타(others)
- 하의(bottom) - 전체, 바지(pants), 치마(skirt)
- 원피스(dress)