### PR TITLE
메인 페이지 커스텀 쇼핑몰 랭킹 미리 보기 API 연결 

### DIFF
--- a/components/LinkButton.tsx
+++ b/components/LinkButton.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+
+type Props = {
+  href: string;
+  guide: string;
+};
+
+export default function LinkButton({ href, guide }: Props) {
+  return (
+    <Link
+      className="inline-block bg-main-color text-white text-sm rounded-lg font-semibold w-48 md:w-60 py-2.5 sm:py-3 mb-4"
+      href={href}
+    >
+      {guide}
+    </Link>
+  );
+}

--- a/components/Malls/MallPreviewCard.tsx
+++ b/components/Malls/MallPreviewCard.tsx
@@ -1,24 +1,26 @@
+'use client';
+
 import { MallPreview } from '@/service/malls';
 import Image from 'next/image';
 import Link from 'next/link';
 
 type Props = { mall: MallPreview };
 
-export default function MallPreview({ mall: { mallId, name, image } }: Props) {
+export default function MallPreview({ mall: { name, image } }: Props) {
   return (
     <div className="text-center">
-      <div className="w-24 h-24 md:w-44 md:h-36 mx-auto">
-        <Link href={`/malls/${mallId}`}>
+      <div className="w-24 h-24 md:w-44 md:h-36 mx-auto mb-2">
+        <Link href={`/malls/${name}`}>
           <Image
-            className="w-full h-full p-2 md:p-4 rounded-lg object-contain mx-auto mb-2 border border-custom-gray-100"
-            src={`/${image}`}
-            alt=""
+            className="w-full h-full p-2 md:p-4 rounded-lg object-contain mx-auto border border-custom-gray-100"
+            src={image}
+            alt={name}
             width={200}
             height={200}
           />
         </Link>
       </div>
-      <Link className="font-semibold text-sm" href={`/malls/${mallId}`}>
+      <Link className="font-semibold text-sm" href={`/malls/${name}`}>
         {name}
       </Link>
     </div>

--- a/components/Malls/RankedMallPreview.tsx
+++ b/components/Malls/RankedMallPreview.tsx
@@ -1,11 +1,31 @@
-import { getRankedMallPreview } from '@/service/malls';
-import RankedMallPreviewGrid from './RankedMallPreviewGrid';
+'use client';
 
-export default async function RankedMallPreview() {
-  const malls = await getRankedMallPreview();
+import { getRankedMallPreview, MallPreview } from '@/service/malls';
+import RankedMallPreviewGrid from './RankedMallPreviewGrid';
+import { useEffect, useState } from 'react';
+import LinkButton from '../LinkButton';
+
+export default function RankedMallPreview() {
+  const [malls, setMalls] = useState<MallPreview[]>([]);
+  useEffect(() => {
+    async function fetchMall() {
+      const data = await getRankedMallPreview();
+      setMalls(data);
+    }
+    fetchMall();
+  }, []);
   return (
-    <div className="w-full p-4 my-2 rounded border border-custom-gray-400">
-      <RankedMallPreviewGrid malls={malls} />
+    <div className="w-full p-4 my-2 rounded border border-custom-gray-400 text-center">
+      {malls.length > 0 ? (
+        <RankedMallPreviewGrid malls={malls} />
+      ) : (
+        <>
+          <span className="block text-custom-gray-800 my-4 text-sm">
+            방문한 쇼핑몰이 없습니다.
+          </span>
+          <LinkButton href="/malls" guide="쇼핑몰 전체 보기" />
+        </>
+      )}
     </div>
   );
 }

--- a/components/Malls/RankedMallPreviewGrid.tsx
+++ b/components/Malls/RankedMallPreviewGrid.tsx
@@ -5,12 +5,13 @@ type Props = { malls: MallPreview[] };
 
 export default function RankedMallPreviewGrid({ malls }: Props) {
   return (
-    <ul className="grid gap-4 h-32 md:h-48 grid-cols-2 xs:grid-cols-3 sm:grid-cols-4 overflow-hidden items-center">
-      {malls.map((mall) => (
-        <li key={mall.mallId}>
-          <MallPreviewCard mall={mall} />
-        </li>
-      ))}
+    <ul className="grid gap-4 h-full md:h-48 grid-cols-2 xs:grid-cols-3 sm:grid-cols-4 overflow-hidden items-center">
+      {malls.length &&
+        malls?.map((mall) => (
+          <li key={mall.mallId}>
+            <MallPreviewCard mall={mall} />
+          </li>
+        ))}
     </ul>
   );
 }

--- a/constants/apis.ts
+++ b/constants/apis.ts
@@ -1,1 +1,1 @@
-export const BASE_URL = "https://fit-tering.com/api/v1";
+export const BASE_URL = "https://sub.fit-tering.com/api/v1";

--- a/service/malls.ts
+++ b/service/malls.ts
@@ -1,5 +1,4 @@
-import { readFile } from 'fs/promises';
-import path from 'path';
+import { customFetch } from '@/utils/customFetch';
 
 export type MallPreview = {
   mallId: number;
@@ -17,7 +16,6 @@ export type Mall = {
 };
 
 export async function getRankedMallPreview(): Promise<MallPreview[]> {
-  // 더미 데이터 읽어옴
-  const filePath = path.join(process.cwd(), 'data', 'malls.json');
-  return readFile(filePath, 'utf-8').then<MallPreview[]>(JSON.parse);
+  const response = await customFetch('/malls/rank/preview');
+  return response.json();
 }


### PR DESCRIPTION
원래 더미 데이터로 표시하여 UI 개발만 마친 메인 페이지 커스텀 쇼핑몰 랭킹 미리 보기를 API에서 불러온 데이터로 표시하도록 수정

### API 요청 base URL 변경
- 서버 API 요청 base URL이 변경되어 수정함
- [fix: API 요청 base URL 변경](https://github.com/YeolJyeongKong/fittering-FE/commit/9e6178c7c64743f135600e5aff5503fd5d6981f1)

### 커스텀 쇼핑몰 랭킹 미리 보기 API 연결
- `/malls/rank/preview`로 API 요청
- 유저가 가입 후 방문한 쇼핑몰이 없어 빈 배열이 응답으로 오는 경우 쇼핑몰 전체 보기 링크 버튼 렌더링
- 가입 후 방문한 쇼핑몰이 있을 경우 순위에 따라 쇼핑몰 미리보기 렌더링
- [feat: 커스텀 쇼핑몰 랭킹 미리 보기 API 연결](https://github.com/YeolJyeongKong/fittering-FE/commit/3708b5d6a72fcd5ca483726dd6680a327cbd8972)
