### PR TITLE
쇼핑몰 관련 버그 수정

### DIFF
--- a/components/Malls/MallPreviewCard.tsx
+++ b/components/Malls/MallPreviewCard.tsx
@@ -10,7 +10,7 @@ export default function MallPreview({ mall: { name, image } }: Props) {
   return (
     <div className="text-center">
       <div className="w-24 h-24 md:w-44 md:h-36 mx-auto mb-2">
-        <Link href={`/malls/${name}`}>
+        <Link href={`/malls/${name.split(' ').join('').toLowerCase()}`}>
           <Image
             className="w-full h-full p-2 md:p-4 rounded-lg object-contain mx-auto border border-custom-gray-100"
             src={image}
@@ -20,7 +20,10 @@ export default function MallPreview({ mall: { name, image } }: Props) {
           />
         </Link>
       </div>
-      <Link className="font-semibold text-sm" href={`/malls/${name}`}>
+      <Link
+        className="font-semibold text-sm"
+        href={`/malls/${name.split(' ').join('').toLowerCase()}`}
+      >
         {name}
       </Link>
     </div>

--- a/components/Malls/RankedMallPreviewGrid.tsx
+++ b/components/Malls/RankedMallPreviewGrid.tsx
@@ -8,7 +8,7 @@ export default function RankedMallPreviewGrid({ malls }: Props) {
     <ul className="grid gap-4 h-full md:h-48 grid-cols-2 xs:grid-cols-3 sm:grid-cols-4 overflow-hidden items-center">
       {malls.length &&
         malls?.map((mall) => (
-          <li key={mall.mallId}>
+          <li key={mall.id}>
             <MallPreviewCard mall={mall} />
           </li>
         ))}

--- a/service/malls.ts
+++ b/service/malls.ts
@@ -1,13 +1,13 @@
 import { customFetch } from '@/utils/customFetch';
 
 export type MallPreview = {
-  mallId: number;
+  id: number;
   name: string;
   image: string;
 };
 
 export type Mall = {
-  mallId: number;
+  id: number;
   name: string;
   url: string;
   description: string;


### PR DESCRIPTION
- 쇼핑몰 랭킹 관련 API 응답 타입 `mallId` -> `id`로 수정
- 쇼핑몰 상세 조회 링크 href를 공백 제거 & 소문자로 변환한 `쇼핑몰 이름`으로 수정