### PR TITLE
검색 기능 구현

### DIFF
--- a/app/(service)/search/page.tsx
+++ b/app/(service)/search/page.tsx
@@ -1,13 +1,44 @@
-import React from 'react';
+'use client';
+
+import React, { useEffect, useState } from 'react';
 import GlobalFilter from '@/components/GlobalFilter';
 import GlobalMenu from '@/components/GlobalMenu';
+import { useSearchParams } from 'next/navigation';
+import { ProductPreview, getProductPreviewPaging } from '@/service/product';
+import ProductsGrid from '@/components/Products/ProductsGrid';
 
 type Props = {};
 
 function SearchPage(props: Props) {
+  const searchParams = useSearchParams();
+  const keyword = searchParams.get('keyword');
+
+  const [products, setProducts] = useState<ProductPreview[]>([]);
+
+  const [filterId, setFilterId] = useState(0);
+  const gender = localStorage.getItem('GLOBAL_FILTER');
+  const url = `/search/${keyword}/${gender}/${filterId}`;
+
+  useEffect(() => {
+    async function fetchProducts() {
+      const data = await getProductPreviewPaging(url);
+      setProducts(data);
+    }
+    fetchProducts();
+  }, [url]);
+
   return (
     <div>
-      검색 결과 페이지
+      <h1 className="text-sm sm:text-lg font-semibold mt-8 mb-2">
+        <span className="text-base sm:text-xl text-main-color">{`'${keyword}'`}</span>
+        에 대한 검색 결과
+      </h1>
+      {products.length !== 0 ? (
+        <ProductsGrid products={products} />
+      ) : (
+        <p className="mt-12 text-xs sm:text-sm text-center text-custom-gray-800">{`'${keyword}'에 대한 검색 결과가 없습니다.`}</p>
+      )}
+
       <GlobalFilter />
       <GlobalMenu />
     </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,8 +5,8 @@ import logo from '/public/Fittering_logo.png';
 import { usePathname } from 'next/navigation';
 import { WebNavbar } from './Navbar/WebNavbar';
 import Link from 'next/link';
-import search from '/public/icon/search_green.svg';
 import { logout } from '../utils/logout';
+import SearchBar from './SearchBar';
 
 const hideURL = ['/login', '/signup'];
 
@@ -29,18 +29,7 @@ export default function Header() {
           />
         </Link>
       </div>
-      <div className="relative w-[78%] xs:w-[80%] md:w-[50%]">
-        <input
-          className="border-[0.5px] bg-custom-gray-50 rounded right-0 w-11/12 md:w-full h-9 md:h-10 pl-4 text-xs absolute top-[50%] translate-y-[-50%]"
-          type="text"
-          placeholder="검색어를 입력하세요."
-        />
-        <Image
-          className="absolute right-0 md:right-1 top-[50%] translate-y-[-50%] md:r-1/12"
-          src={search}
-          alt=""
-        />
-      </div>
+      <SearchBar />
       <div className="hidden w-0 md:inline-block md:relative md:w-[33%]">
         <WebNavbar />
         <button

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -30,11 +30,9 @@ export default function SearchBar() {
         onChange={handleKeywordChange}
         value={keyword}
       />
-      <Image
-        className="absolute right-0 md:right-1 top-[50%] translate-y-[-50%] md:r-1/12"
-        src={search}
-        alt=""
-      />
+      <button className="absolute right-0 md:right-1 top-[50%] translate-y-[-50%] md:r-1/12">
+        <Image src={search} alt="" />
+      </button>
     </form>
   );
 }

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import Image from 'next/image';
+import search from '/public/icon/search_green.svg';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function SearchBar() {
+  const [keyword, setKeyword] = useState('');
+  const router = useRouter();
+
+  const handleKeywordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setKeyword(e.target.value);
+  };
+
+  const handleSearch = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    router.push(`/search?keyword=${keyword}`);
+  };
+
+  return (
+    <form
+      onSubmit={handleSearch}
+      className="relative w-[78%] xs:w-[80%] md:w-[50%]"
+    >
+      <input
+        className="border-[0.5px] bg-custom-gray-50 rounded right-0 w-11/12 md:w-full h-9 md:h-10 pl-4 text-xs absolute top-[50%] translate-y-[-50%]"
+        type="text"
+        placeholder="검색어를 입력하세요."
+        onChange={handleKeywordChange}
+        value={keyword}
+      />
+      <Image
+        className="absolute right-0 md:right-1 top-[50%] translate-y-[-50%] md:r-1/12"
+        src={search}
+        alt=""
+      />
+    </form>
+  );
+}

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -3,10 +3,15 @@
 import Image from 'next/image';
 import search from '/public/icon/search_green.svg';
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 
 export default function SearchBar() {
-  const [keyword, setKeyword] = useState('');
+  const pathname = usePathname();
+  const searchParam = useSearchParams();
+
+  const [keyword, setKeyword] = useState(
+    pathname === '/search' ? searchParam.get('keyword') ?? '' : ''
+  );
   const router = useRouter();
 
   const handleKeywordChange = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## 검색 기능 구현

#### [feat: 검색 페이지 라우팅](https://github.com/YeolJyeongKong/fittering-FE/commit/690a0796a5c4930b120bf94262fda72c04b00ddd)
- 검색창을 폼으로 만들어 `enter` 키 입력 시에도 검색 결과 페이지로 넘어가도록 변경
- 검색 시 `/search?keyword=${keyword}`로 이동

#### [feat: 검색 API 연결](https://github.com/YeolJyeongKong/fittering-FE/commit/04255d42cfd29158f8e6b76e54398312b3c1941a)
- `fetch` 해 온 검색 결과 상품 렌더링

#### [fix: 검색창 돋보기 버튼으로 수정](https://github.com/YeolJyeongKong/fittering-FE/commit/39a602efe1c44c24f4e4f75816bf28a83e031243)
- 검색창의 돋보기 `Image`를 `button` 태그로 감싸 클릭으로도 검색 가능하도록 수정


#### [fix: 새로고침 시 검색창에 검색어 사라짐 해결](https://github.com/YeolJyeongKong/fittering-FE/commit/49410704dd24c9102b107e0b703cd69bb1780b4a)
- 검색 결과 페이지에서 새로고침 시 검색창에 검색어가 사라지는 버그 해결
- 검색 결과 페이지의 경우 검색창의 초기 값을 `keyword` query string에 해당하는 값으로 수정