### PR TITLE
상품 정렬 기준 드롭다운 목록 개발

### DIFF
--- a/app/(service)/search/page.tsx
+++ b/app/(service)/search/page.tsx
@@ -6,6 +6,7 @@ import GlobalMenu from '@/components/GlobalMenu';
 import { useSearchParams } from 'next/navigation';
 import { ProductPreview, getProductPreviewPaging } from '@/service/product';
 import ProductsGrid from '@/components/Products/ProductsGrid';
+import FilterIdDropdown from '@/components/FilterIdDropdown';
 
 type Props = {};
 
@@ -33,6 +34,7 @@ function SearchPage(props: Props) {
         <span className="text-base sm:text-xl text-main-color">{`'${keyword}'`}</span>
         에 대한 검색 결과
       </h1>
+      <FilterIdDropdown setFilterId={setFilterId} />
       {products.length !== 0 ? (
         <ProductsGrid products={products} />
       ) : (

--- a/components/FilterIdDropdown.tsx
+++ b/components/FilterIdDropdown.tsx
@@ -1,0 +1,24 @@
+import { FILTER_ID } from '@/constants/filterId';
+
+type Props = {
+  setFilterId: React.Dispatch<React.SetStateAction<number>>;
+};
+
+export default function FilterIdDropdown({ setFilterId }: Props) {
+  const handleFilterIdChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setFilterId(Number(e.target.value));
+  };
+
+  return (
+    <select
+      className="block mt-3 ml-auto text-sm border p-1 rounded"
+      onChange={handleFilterIdChange}
+    >
+      {FILTER_ID.map((filter) => (
+        <option key={filter.id} value={filter.id}>
+          {filter.name}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/components/Products/CategoryProducts.tsx
+++ b/components/Products/CategoryProducts.tsx
@@ -3,6 +3,7 @@
 import { getProductPreviewPaging, ProductPreview } from '@/service/product';
 import { categoryNameToIndex } from '@/utils/categoryNameToIndex';
 import { useState, useEffect } from 'react';
+import FilterIdDropdown from '../FilterIdDropdown';
 import ProductsGrid from './ProductsGrid';
 
 type Props = {
@@ -28,5 +29,10 @@ export default function CategoryProducts({ categoryName }: Props) {
 
     fetchProducts();
   }, [url]);
-  return <ProductsGrid products={products} />;
+  return (
+    <>
+      <FilterIdDropdown setFilterId={setFilterId} />
+      <ProductsGrid products={products} />
+    </>
+  );
 }

--- a/constants/filterId.ts
+++ b/constants/filterId.ts
@@ -1,0 +1,6 @@
+export const FILTER_ID = [
+  { id: 0, name: '최신순' },
+  { id: 1, name: '조회수순' },
+  { id: 2, name: '낮은 가격순' },
+  { id: 3, name: '높은 가격순' },
+];


### PR DESCRIPTION
## 상품 정렬 기준 드롭다운 목록 개발
- 카테고리별 상품 조회 / 검색 결과 페이지에 상품 정렬 기준 선택 드롭다운 메뉴 추가
- default 정렬 기준은 `0` (최신순)
- 선택한 `filterId`로 카테고리별 상품 조회 API / 검색 API 요청

### filterId(상품 정렬 기준)
- 0 : 최신순
- 1 : 조회수순
- 2 : 낮은 가격순
- 3 : 높은 가격순