### PR TITLE
API 연결 코드 수정

### DIFF
--- a/app/(service)/categories/[[...categoryName]]/page.tsx
+++ b/app/(service)/categories/[[...categoryName]]/page.tsx
@@ -1,7 +1,11 @@
 import GlobalFilter from '@/components/GlobalFilter';
 import GlobalMenu from '@/components/GlobalMenu';
-import CategoryProducts from '@/components/Products/CategoryProducts';
+import { getProductPreviewPagingWithoutToken } from '@/service/product';
+import { CategoryProductsData } from '@/types/categoryProducts';
 import React from 'react';
+import { outer, top, dress, bottom } from '@/types/categories';
+import { FILTER_ID } from '@/constants/filterId';
+import CategoryProducts from '@/components/Products/CategoryProducts';
 
 type Props = {
   params: {
@@ -9,11 +13,68 @@ type Props = {
   };
 };
 
-function CategoryPage({ params: { categoryName } }: Props) {
+export const revalidate = 3600 * 24 * 14;
+
+const categories = [outer, top, dress, bottom];
+
+const mainCategoryId = [0, ...categories.map((category) => category.index)];
+const subCategoryId = categories
+  .map((category) => category.sub.map((sub) => sub.index))
+  .flat();
+const genders: ('A' | 'M' | 'F')[] = ['A', 'M', 'F'];
+const filterIds = FILTER_ID.map((filter) => filter.id);
+
+async function fetchCategoriesProducts(
+  categoryType: 'main' | 'sub',
+  categoryId: number,
+  gender: string,
+  filterId: number
+) {
+  if (categoryType === 'main') {
+    return await getProductPreviewPagingWithoutToken(
+      `/categories/${categoryId}/${gender}/${filterId}`
+    );
+  }
+  return await getProductPreviewPagingWithoutToken(
+    `/categories/sub/${categoryId}/${gender}/${filterId}`
+  );
+}
+
+async function getCategoriesProductsData(categoryType: 'main' | 'sub') {
+  const categoryIds = categoryType === 'main' ? mainCategoryId : subCategoryId;
+  let data: CategoryProductsData[] = [];
+
+  for (const categoryId of categoryIds) {
+    for (const gender of genders) {
+      for (const filterId of filterIds) {
+        data.push({
+          categoryId: categoryId,
+          gender: gender,
+          filterId: filterId,
+          contents: await fetchCategoriesProducts(
+            categoryType,
+            categoryId,
+            gender,
+            filterId
+          ),
+        });
+      }
+    }
+  }
+
+  return data;
+}
+
+async function CategoryPage({ params: { categoryName } }: Props) {
+  const mainCategoriesProducts = await getCategoriesProductsData('main');
+  const subCategoriesProducts = await getCategoriesProductsData('sub');
+
   return (
     <div>
       <CategoryProducts
         categoryName={categoryName === undefined ? [] : categoryName}
+        mainCategoriesProducts={mainCategoriesProducts}
+        subCategoriesProducts={subCategoriesProducts}
       />
       <GlobalFilter />
       <GlobalMenu />

--- a/components/FilterIdDropdown.tsx
+++ b/components/FilterIdDropdown.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { FILTER_ID } from '@/constants/filterId';
 
 type Props = {

--- a/components/Form/SignupForm.tsx
+++ b/components/Form/SignupForm.tsx
@@ -69,7 +69,7 @@ export const SignupForm = () => {
       day,
       password,
     });
-    if (response.status === 200) {
+    if (response.status === 201) {
       window.alert('회원가입이 완료되었습니다. 로그인 페이지로 이동합니다.');
       router.replace('/login');
     } else {

--- a/components/Products/CategoryProducts.tsx
+++ b/components/Products/CategoryProducts.tsx
@@ -1,34 +1,59 @@
 'use client';
 
-import { getProductPreviewPaging, ProductPreview } from '@/service/product';
 import { categoryNameToIndex } from '@/utils/categoryNameToIndex';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import FilterIdDropdown from '../FilterIdDropdown';
 import ProductsGrid from './ProductsGrid';
+import { CategoryProductsData } from '@/types/categoryProducts';
 
 type Props = {
   categoryName: string[];
+  mainCategoriesProducts: CategoryProductsData[];
+  subCategoriesProducts: CategoryProductsData[];
 };
 
-export default function CategoryProducts({ categoryName }: Props) {
-  const [products, setProducts] = useState<ProductPreview[]>([]);
+function setProducts(
+  { categoryName, mainCategoriesProducts, subCategoriesProducts }: Props,
+  gender: string,
+  filterId: number
+) {
+  if (categoryName.length === 0)
+    return mainCategoriesProducts.filter(
+      (products) =>
+        products.categoryId === 0 &&
+        products.gender === gender &&
+        products.filterId === filterId
+    )[0].contents;
+
+  if (categoryName.length === 1)
+    return mainCategoriesProducts.filter(
+      (products) =>
+        products.categoryId === categoryNameToIndex(categoryName) &&
+        products.gender === gender &&
+        products.filterId === filterId
+    )[0].contents;
+
+  return subCategoriesProducts.filter(
+    (products) =>
+      products.categoryId === categoryNameToIndex(categoryName) &&
+      products.gender === gender &&
+      products.filterId === filterId
+  )[0].contents;
+}
+
+export default function CategoryProducts({
+  categoryName,
+  mainCategoriesProducts,
+  subCategoriesProducts,
+}: Props) {
+  const gender = localStorage.getItem('GLOBAL_FILTER') ?? 'A';
   const [filterId, setFilterId] = useState(0);
-  const categoryId =
-    categoryName.length === 0 ? 0 : categoryNameToIndex(categoryName);
-  const gender = localStorage.getItem('GLOBAL_FILTER');
-  const url =
-    '/categories' +
-    (categoryName.length === 2 ? '/sub' : '') +
-    `/${categoryId}/${gender}/${filterId}`;
+  const products = setProducts(
+    { categoryName, mainCategoriesProducts, subCategoriesProducts },
+    gender,
+    filterId
+  );
 
-  useEffect(() => {
-    async function fetchProducts() {
-      const data = await getProductPreviewPaging(url);
-      setProducts(data);
-    }
-
-    fetchProducts();
-  }, [url]);
   return (
     <>
       <FilterIdDropdown setFilterId={setFilterId} />

--- a/constants/apis.ts
+++ b/constants/apis.ts
@@ -1,2 +1,3 @@
 export const BASE_URL = "https://sub.fit-tering.com/api/v1";
+export const AUTH_URL = "https://sub.fit-tering.com/api/v1/auth";
 export const SERVER_DOMAIN = "https://sub.fit-tering.com";

--- a/service/malls.ts
+++ b/service/malls.ts
@@ -17,5 +17,8 @@ export type Mall = {
 
 export async function getRankedMallPreview(): Promise<MallPreview[]> {
   const response = await customFetch('/malls/rank/preview');
+  if (!response.ok) {
+    return [];
+  }
   return response.json();
 }

--- a/service/product.ts
+++ b/service/product.ts
@@ -1,4 +1,4 @@
-import { customFetch } from '@/utils/customFetch';
+import { customFetch, serverFetch } from '@/utils/customFetch';
 
 export type ProductPreview = {
   productId: number;
@@ -27,6 +27,27 @@ export async function getProductPreviewPaging(
   url: string
 ): Promise<ProductPreview[]> {
   const response = await customFetch(url);
+  if (!response.ok) {
+    return [];
+  }
+  const data: ProductPreviewResponse = await response.json();
+  return data.content;
+}
+
+export async function getProductPreviewWithoutToken(
+  url: string
+): Promise<ProductPreview[]> {
+  const response = await serverFetch(url);
+  if (!response.ok) {
+    return [];
+  }
+  return await response.json();
+}
+
+export async function getProductPreviewPagingWithoutToken(
+  url: string
+): Promise<ProductPreview[]> {
+  const response = await serverFetch(url);
   if (!response.ok) {
     return [];
   }

--- a/service/product.ts
+++ b/service/product.ts
@@ -17,6 +17,9 @@ export async function getProductPreview(
   url: string
 ): Promise<ProductPreview[]> {
   const response = await customFetch(url);
+  if (!response.ok) {
+    return [];
+  }
   return await response.json();
 }
 
@@ -24,6 +27,9 @@ export async function getProductPreviewPaging(
   url: string
 ): Promise<ProductPreview[]> {
   const response = await customFetch(url);
+  if (!response.ok) {
+    return [];
+  }
   const data: ProductPreviewResponse = await response.json();
   return data.content;
 }

--- a/types/categoryProducts.ts
+++ b/types/categoryProducts.ts
@@ -1,0 +1,8 @@
+import { ProductPreview } from '@/service/product';
+
+export type CategoryProductsData = {
+  categoryId: number;
+  gender: 'A' | 'M' | 'F';
+  filterId: number;
+  contents: ProductPreview[]
+}

--- a/utils/customFetch.ts
+++ b/utils/customFetch.ts
@@ -1,5 +1,4 @@
-import { BASE_URL } from '@/constants/apis';
-import { login } from '@/service/auth';
+import { AUTH_URL } from '@/constants/apis';
 
 const accessToken =
   typeof window !== 'undefined' ? localStorage.getItem('TOKEN') : null;
@@ -14,7 +13,7 @@ export async function customFetch(
   options?: RequestInit
 ): Promise<Response> {
   const headers = { ...defaultHeaders, ...options?.headers };
-  const mergedURL = BASE_URL + url;
+  const mergedURL = AUTH_URL + url;
   const mergedOptions = { ...options, headers };
 
   const response = await fetch(mergedURL, mergedOptions);

--- a/utils/customFetch.ts
+++ b/utils/customFetch.ts
@@ -1,4 +1,4 @@
-import { AUTH_URL } from '@/constants/apis';
+import { AUTH_URL, BASE_URL } from '@/constants/apis';
 
 const accessToken =
   typeof window !== 'undefined' ? localStorage.getItem('TOKEN') : null;
@@ -22,6 +22,19 @@ export async function customFetch(
     localStorage.removeItem('TOKEN');
     window.location.replace('/login');
   }
+
+  return response;
+}
+
+export async function serverFetch(
+  url: string,
+  options?: RequestInit
+): Promise<Response> {
+  const headers = { 'Content-Type': 'application/json', ...options?.headers };
+  const mergedURL = BASE_URL + url;
+  const mergedOptions = { ...options, headers };
+  
+  const response = await fetch(mergedURL, mergedOptions);
 
   return response;
 }


### PR DESCRIPTION
## API 연결 코드 수정

### 회원가입 성공 시 코드 200에서 201로 바뀐 것 처리하기
백엔드에서 회원가입 API 요청 후 성공 시 응답 코드를 `200 OK`에서 `201 CREATED`로 변경함에 따라 회원가입 성공 체크를 `response.status === 201`로 바꿈
- [fix: 회원가입 성공 시 응답 코드 수정](https://github.com/YeolJyeongKong/fittering-FE/commit/ababc2f3bb1b1074daf8ce49f0fbcad0c25115be)


### 토큰 필요 있는 API 요청 URL 수정 (URL에 /auth추가)
백엔드에서 유저가 로그인할 때 발급받은 토큰을 헤더에 포함해야 하는 API의 URL에 `/auth`를 붙이도록 변경함에 따라 토큰이 필요한 API의 요청 URL을 수정함
- [fix: 토큰 필요 있는 API 요청 URL 수정](https://github.com/YeolJyeongKong/fittering-FE/commit/7df5b1528ac7d4067ad38b6268c086cf791cdc33)


### 토큰 만료 후 API 요청 시 로그인 페이지로 redirect 되기 전 뜨는 에러 해결
토큰 만료 후 상품 데이터를 가져오는 API를 요청했을 때 `401 Unauthorized`와 함께 데이터가 오지 않아 `undefined`를 접근하려 했기 때문에 발생한 에러
→ data fetch에 실패할 경우 빈 배열을 리턴하도록 수정
- [fix: API 요청 실패 시 빈 배열 리턴하도록 수정](https://github.com/YeolJyeongKong/fittering-FE/commit/3ef1180b9ad379cd69f211a70d4981442c0b6395)


### 카테고리별 상품 조회 API - 서버 컴포넌트에서 data fetch 하도록 수정
카테고리별 상품 조회 API는 모든 유저들에게 같은 데이터를 제공하는 API이므로 토큰이 필요 없도록 수정하였음
→ 원래 클라이언트 컴포넌트에서 토큰을 넣어 data fetch 후 처리하던 방식에서 서버 컴포넌트에서 data fetch한 후 클라이언트 컴포넌트에서 필터링하여 보여주는 방식으로 변경
- [fix: 카테고리별 상품 조회 API 서버 컴포넌트에서 data fetch 하도록 수정](https://github.com/YeolJyeongKong/fittering-FE/commit/072a4f0412fa37a3618744352c1d17dcf058516e)
- [관련 포스팅](https://velog.io/@thumbzzero/Fittering-%EA%B0%9C%EB%B0%9C-%EA%B8%B0%EB%A1%9D-Next.js-13-%EC%84%9C%EB%B2%84-%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8-data-fetch-%EA%B4%80%EB%A0%A8-%ED%8A%B8%EB%9F%AC%EB%B8%94-%EC%8A%88%ED%8C%85)