### PR TITLE
쇼핑몰 랭킹/즐겨찾기 조회 관련 버그 수정

### DIFF
--- a/components/Malls/MallPreviewCard.tsx
+++ b/components/Malls/MallPreviewCard.tsx
@@ -35,6 +35,7 @@ export default function MallPreviewCard({ malls }: Props) {
             {mall.products.map((product) => (
               <MallPreviewImage
                 key={product.productId}
+                productId={product.productId}
                 productImage={product.productImage}
               />
             ))}

--- a/components/Malls/MallPreviewImage.tsx
+++ b/components/Malls/MallPreviewImage.tsx
@@ -1,21 +1,23 @@
-import Image from "next/image";
+import Image from 'next/image';
+import Link from 'next/link';
 
 type Props = {
+  productId: number;
   productImage: string;
 };
 
-export default function MallPreviewImage({ productImage }: Props) {
+export default function MallPreviewImage({ productId, productImage }: Props) {
   return (
-    <div
-      className="relative after:block after:pb-[100%]"
-    >
-      <Image
-        className="w-full h-full border rounded object-contain absolute top-0 left-0"
-        src={productImage}
-        alt=""
-        width={100}
-        height={100}
-      />
+    <div className="relative after:block after:pb-[100%]">
+      <Link href={`/products/${productId}`}>
+        <Image
+          className="w-full h-full border rounded object-contain absolute top-0 left-0"
+          src={productImage}
+          alt=""
+          width={100}
+          height={100}
+        />
+      </Link>
     </div>
   );
 }

--- a/components/Malls/RankedMallPreview.tsx
+++ b/components/Malls/RankedMallPreview.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { getRankedMallPreview, MallPreview } from '@/service/malls';
+import { getRankedMallPreview, MallRankingPreview } from '@/service/malls';
 import RankedMallPreviewGrid from './RankedMallPreviewGrid';
 import { useEffect, useState } from 'react';
 import LinkButton from '../LinkButton';
 
 export default function RankedMallPreview() {
-  const [malls, setMalls] = useState<MallPreview[]>([]);
+  const [malls, setMalls] = useState<MallRankingPreview[]>([]);
   useEffect(() => {
     async function fetchMall() {
       const data = await getRankedMallPreview();

--- a/components/Malls/RankedMallPreviewCard.tsx
+++ b/components/Malls/RankedMallPreviewCard.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { MallRankingPreview } from '@/service/malls';
+import Image from 'next/image';
+import Link from 'next/link';
+
+type Props = { mall: MallRankingPreview };
+
+export default function RankedMallPreviewCard({ mall: { name, image } }: Props) {
+  return (
+    <div className="text-center">
+      <div className="w-24 h-24 md:w-44 md:h-36 mx-auto mb-2">
+        <Link href={`/malls/${name.split(' ').join('').toLowerCase()}`}>
+          <Image
+            className="w-full h-full p-2 md:p-4 rounded-lg object-contain mx-auto border border-custom-gray-100"
+            src={image}
+            alt={name}
+            width={200}
+            height={200}
+          />
+        </Link>
+      </div>
+      <Link
+        className="font-semibold text-sm"
+        href={`/malls/${name.split(' ').join('').toLowerCase()}`}
+      >
+        {name}
+      </Link>
+    </div>
+  );
+}

--- a/components/Malls/RankedMallPreviewGrid.tsx
+++ b/components/Malls/RankedMallPreviewGrid.tsx
@@ -1,7 +1,7 @@
-import { MallPreview } from '@/service/malls';
-import MallPreviewCard from './MallPreviewCard';
+import { MallRankingPreview } from '@/service/malls';
+import RankedMallPreviewCard from './RankedMallPreviewCard';
 
-type Props = { malls: MallPreview[] };
+type Props = { malls: MallRankingPreview[] };
 
 export default function RankedMallPreviewGrid({ malls }: Props) {
   return (
@@ -9,7 +9,7 @@ export default function RankedMallPreviewGrid({ malls }: Props) {
       {malls.length &&
         malls?.map((mall) => (
           <li key={mall.id}>
-            <MallPreviewCard mall={mall} />
+            <RankedMallPreviewCard mall={mall} />
           </li>
         ))}
     </ul>

--- a/service/malls.ts
+++ b/service/malls.ts
@@ -4,6 +4,7 @@ export type MallRankingPreview = {
   id: number;
   name: string;
   image: string;
+  isFavorite: boolean;
 };
 
 export type MallPreview = {


### PR DESCRIPTION
- 쇼핑몰 랭킹/즐겨찾기 전체보기에 있는 상품 미리보기 사진 누르면 해당 상품 페이지(`/products/${productId}`)로 링크 넘어가도록 수정
- 메인 페이지 쇼핑몰 랭킹 미리보기 응답 타입 수정
  `MallPreview[]` → `MallRankingPreview[]`
```ts
export type MallRankingPreview = {
  id: number;
  name: string;
  image: string;
  isFavorite: boolean;
};
```