### PR TITLE
체형 실루엣 이미지 제공 API 연결

### DIFF
--- a/components/MyPage/MySize/SmartAnalysisPhotoSubmitForm.tsx
+++ b/components/MyPage/MySize/SmartAnalysisPhotoSubmitForm.tsx
@@ -1,19 +1,65 @@
+'use client';
+
+import { getSilhouetteImage } from '@/service/mysize';
 import Image from 'next/image';
 import plus from 'public/icon/plus_white.svg';
+import { useRef, useState } from 'react';
 
 type Props = {
   photoType: 'FRONT' | 'SIDE';
 };
 
 export default function SmartAnalysisPhotoSubmitForm({ photoType }: Props) {
+  const imageInput = useRef<HTMLInputElement>(null);
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+
+  const handleImageInputClick = () => {
+    imageInput.current?.click();
+  };
+
+  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    const file = e.target.files?.[0];
+    if (file) {
+      const formData = new FormData();
+      formData.append('bodyFile', file);
+      const imageUrl = await getSilhouetteImage(photoType, formData);
+      setImageUrl(imageUrl);
+    }
+  };
+
   return (
-    <div className="flex flex-col gap-4 items-center justify-center border rounded-lg w-full h-[54vh] text-center">
-      <button className="bg-main-color text-white text-[3rem] rounded-full w-16 h-16">
-        <Image className="mx-auto" src={plus} alt="+" />
-      </button>
-      <span className="text-main-color">
-        {photoType === 'FRONT' ? '정면' : '측면'} 사진 등록
-      </span>
+    <div
+      onClick={handleImageInputClick}
+      className="flex flex-col gap-4 items-center justify-center border rounded-lg w-full h-[54vh] text-center"
+    >
+      {imageUrl === null ? (
+        <>
+          <form encType="multipart/form-data">
+            <input
+              className="hidden"
+              type="file"
+              accept=".jpg, .jpeg, .png"
+              ref={imageInput}
+              onChange={handleFileUpload}
+            />
+          </form>
+          <button className="bg-main-color text-white text-[3rem] rounded-full w-16 h-16">
+            <Image className="mx-auto" src={plus} alt="+" />
+          </button>
+          <span className="text-main-color">
+            {photoType === 'FRONT' ? '정면' : '측면'} 사진 등록
+          </span>
+        </>
+      ) : (
+        <Image
+          className="w-full h-full p-4 rounded-sm object-contain"
+          src={imageUrl}
+          alt="실루엣 사진"
+          width={200}
+          height={200}
+        />
+      )}
     </div>
   );
 }

--- a/service/mysize.ts
+++ b/service/mysize.ts
@@ -1,3 +1,4 @@
+import { customFetch } from '@/utils/customFetch';
 import { readFile } from 'fs/promises';
 import path from 'path';
 
@@ -17,4 +18,23 @@ export async function getMySize(): Promise<MySize> {
   // 더미 데이터 읽어옴
   const filePath = path.join(process.cwd(), 'data', 'mysize.json');
   return readFile(filePath, 'utf-8').then<MySize>(JSON.parse);
+}
+
+export async function getSilhouetteImage(
+  type: 'FRONT' | 'SIDE',
+  formData: FormData
+): Promise<string | null> {
+  const response = await customFetch(
+    `/users/mysize/silhouette?type=${type}`,
+    {
+      method: 'POST',
+      body: formData,
+    },
+    true
+  );
+  if (!response.ok) {
+    return null;
+  }
+  const data: { url: string } = await response.json();
+  return data.url;
 }

--- a/utils/customFetch.ts
+++ b/utils/customFetch.ts
@@ -10,9 +10,12 @@ const defaultHeaders = {
 
 export async function customFetch(
   url: string,
-  options?: RequestInit
+  options?: RequestInit,
+  isFileUpload?: boolean
 ): Promise<Response> {
-  const headers = { ...defaultHeaders, ...options?.headers };
+  const headers = isFileUpload
+    ? { Authorization: `${accessToken}`, ...options?.headers }
+    : { ...defaultHeaders, ...options?.headers };
   const mergedURL = AUTH_URL + url;
   const mergedOptions = { ...options, headers };
 
@@ -33,7 +36,7 @@ export async function serverFetch(
   const headers = { 'Content-Type': 'application/json', ...options?.headers };
   const mergedURL = BASE_URL + url;
   const mergedOptions = { ...options, headers };
-  
+
   const response = await fetch(mergedURL, mergedOptions);
 
   return response;


### PR DESCRIPTION
## customFetch 파라미터 및 헤더 수정
- 추가 파라미터로 `isFileUpload?: boolean`를 optional하게 입력받도록 하여 스마트 분석 기능과 같이 `FormData`로 파일을 전송해야 하는 API를 fetch할 때 요청 헤더의 `'Content-Type'`을 `'application/json'`으로 전송하지 않도록 수정
```ts
const defaultHeaders = {
  'Content-Type': 'application/json',
  Authorization: `${accessToken}`,
};

const headers = isFileUpload
    ? { Authorization: `${accessToken}`, ...options?.headers }
    : { ...defaultHeaders, ...options?.headers };
```

## 체형 실루엣 이미지 제공 API 연결
스마트 분석 페이지(`/user/mysize/smart_analysis`)에서 정면/측면 사진 이미지 파일 등록 시 실루엣 반환 API(`/auth/users/mysize/silhouette?type=${type}`)를 연결하여 실루엣 미리보기 사진 띄우기

- `type: 'FRONT' | 'SIDE'`
- 등록 가능 사진 확장자 : `accept=".jpg, .jpeg, .png"`
- `FormData`로 `bodyFile` key에 이미지 file 넣어 전송
- 체형 실루엣 이미지 제공 API fetch 성공 시 `null`로 초기화된 `imageUrl`을 응답으로 받은 `url`로 업데이트
- `imageUrl`이 `null`이 아닐 때 사진 등록 `form`이 아닌 `src`가 `imageUrl`인 `Image` 렌더링