### PR TITLE
회원 탈퇴 API 연결

### DIFF
--- a/components/Form/UserDeleteForm.tsx
+++ b/components/Form/UserDeleteForm.tsx
@@ -99,7 +99,7 @@ export const UserDeleteForm = () => {
           className="text-xs md:text-base absolute left-[50%] translate-x-[-50%] rounded-3xl px-4 py-2 bg-main-color text-[white] font-bold border-none disabled:opacity-70"
           disabled={!isDeleteFormValid}
         >
-          탈퇴
+          탈퇴하기
         </button>
       </div>
     </form>

--- a/components/Form/UserDeleteForm.tsx
+++ b/components/Form/UserDeleteForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { deleteUser } from '@/service/user';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 const divStyle = 'my-4 inline-block w-full md:w-3/5';
@@ -12,6 +12,7 @@ export const UserDeleteForm = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [passwordConfirm, setPasswordConfirm] = useState('');
+  const [isDeleteFormValid, setIsDeleteFormValid] = useState(false);
 
   const router = useRouter();
 
@@ -28,6 +29,12 @@ export const UserDeleteForm = () => {
   ) => {
     setPasswordConfirm(e.target.value);
   };
+
+  useEffect(() => {
+    setIsDeleteFormValid(
+      email.length > 0 && password.length > 0 && passwordConfirm.length > 0
+    );
+  }, [email, password, passwordConfirm]);
 
   const handleUserDelete = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -88,7 +95,10 @@ export const UserDeleteForm = () => {
         />
       </div>
       <div className="relative mt-16 w-full md:w-1/2">
-        <button className="text-xs md:text-base absolute left-[50%] translate-x-[-50%] rounded-3xl px-4 py-2 bg-main-color text-[white] font-bold border-none">
+        <button
+          className="text-xs md:text-base absolute left-[50%] translate-x-[-50%] rounded-3xl px-4 py-2 bg-main-color text-[white] font-bold border-none disabled:opacity-70"
+          disabled={!isDeleteFormValid}
+        >
           탈퇴
         </button>
       </div>

--- a/components/Form/UserDeleteForm.tsx
+++ b/components/Form/UserDeleteForm.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { deleteUser } from '@/service/user';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 const divStyle = 'my-4 inline-block w-full md:w-3/5';
 const infoTypeLabelStyle = 'block my-2';
@@ -10,6 +12,8 @@ export const UserDeleteForm = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [passwordConfirm, setPasswordConfirm] = useState('');
+
+  const router = useRouter();
 
   const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(e.target.value);
@@ -25,12 +29,27 @@ export const UserDeleteForm = () => {
     setPasswordConfirm(e.target.value);
   };
 
-  const handleDeleteButtonClick = (
-    e: React.MouseEvent<HTMLButtonElement>
-  ) => {};
+  const handleUserDelete = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (password !== passwordConfirm) {
+      window.alert('이메일 또는 비밀번호를 확인해주세요.');
+      return;
+    }
+    const response = await deleteUser({ email, password });
+    if (response.ok) {
+      window.alert('회원탈퇴가 완료되었습니다.');
+      localStorage.removeItem('TOKEN');
+      router.replace('/login');
+    } else {
+      window.alert('이메일 또는 비밀번호를 확인해주세요.');
+    }
+  };
 
   return (
-    <form className="w-full flex flex-col items-center justify-center md:mt-6">
+    <form
+      onSubmit={handleUserDelete}
+      className="w-full flex flex-col items-center justify-center md:mt-6"
+    >
       <div className={divStyle}>
         <label className={infoTypeLabelStyle} htmlFor="email">
           이메일
@@ -69,10 +88,7 @@ export const UserDeleteForm = () => {
         />
       </div>
       <div className="relative mt-16 w-full md:w-1/2">
-        <button
-          className="text-xs md:text-base absolute left-[50%] translate-x-[-50%] rounded-3xl px-4 py-2 bg-main-color text-[white] font-bold border-none"
-          onClick={handleDeleteButtonClick}
-        >
+        <button className="text-xs md:text-base absolute left-[50%] translate-x-[-50%] rounded-3xl px-4 py-2 bg-main-color text-[white] font-bold border-none">
           탈퇴
         </button>
       </div>

--- a/service/user.ts
+++ b/service/user.ts
@@ -1,0 +1,15 @@
+import { customFetch } from '@/utils/customFetch';
+
+export async function deleteUser({
+  email,
+  password,
+}: {
+  email: string;
+  password: string;
+}): Promise<Response> {
+  const response = await customFetch('/users', {
+    method: 'DELETE',
+    body: JSON.stringify({ email, password }),
+  });
+  return response;
+}


### PR DESCRIPTION
## API 연결
- 회원 탈퇴(DELETE) : `/auth/users`
- [feat: 회원 탈퇴 API 연결](https://github.com/YeolJyeongKong/fittering-FE/commit/283aaf2232fb8f17c41422e7e051c23ee31634ad)


## 회원 탈퇴 버튼 비활성화/활성화
<table> 
  <tr>
    <td valign="middle"><img width="200" alt="image" src="https://github.com/YeolJyeongKong/fittering-FE/assets/94180099/1279405d-52fe-44af-b4e9-a6f105bcd0e8">
<img width="200" alt="image" src="https://github.com/YeolJyeongKong/fittering-FE/assets/94180099/03c9f1f4-ecbe-4e5c-8e06-e9999b6b816c">
</td>
    <td valign="middle"><img width="200" alt="image" src="https://github.com/YeolJyeongKong/fittering-FE/assets/94180099/47cbd558-6805-4425-a29f-bd45c2dbe5b9"></td>
  </tr>
  <tr>
    <td valign="middle" align="center">회원 탈퇴 폼 입력 완료 전</td>
    <td valign="middle" align="center">회원 탈퇴 폼 입력 완료 후</td>
  </tr>
</table>

회원 탈퇴 폼의 모든 항목을 다 입력하였을 때만 탈퇴하기 버튼이 활성화되도록 하였고, 버튼이 비활성화된 상태에서는 버튼에 투명도를 설정하여 눈으로 쉽게 확인할 수 있게 하였다.

- [feat: 회원 탈퇴 버튼 활성화 조건 추가](https://github.com/YeolJyeongKong/fittering-FE/commit/df590e272a3f2d6c6a2231c878f79565c96786e4)


## 회원 탈퇴 버튼 문구 수정
- `탈퇴` → `탈퇴하기` 로 수정
- [fix: 회원 탈퇴 버튼 문구 수정](https://github.com/YeolJyeongKong/fittering-FE/commit/29a1ba5f4e736eaa1b8f1e8635f2925fad7ba588)
