### PR TITLE
비밀번호 변경 기능 추가

### DIFF
--- a/components/Form/PasswordEditForm.tsx
+++ b/components/Form/PasswordEditForm.tsx
@@ -84,7 +84,7 @@ export const PasswordEditForm = () => {
             className={
               isPasswordValid || newPassword.length === 0
                 ? 'hidden'
-                : 'ml-4 text-red-500 text-xs'
+                : 'ml-4 text-red-500 text-xs hidden md:inline'
             }
           >
             ※ 비밀번호: 8~15자의 영문 대/소문자, 숫자, 특수문자를 사용해 주세요.
@@ -99,6 +99,15 @@ export const PasswordEditForm = () => {
           value={newPassword}
           onChange={handleNewPasswordChange}
         />
+        <span
+          className={
+            isPasswordValid || newPassword.length === 0
+              ? 'hidden'
+              : 'my-1 text-red-500 text-xs md:hidden'
+          }
+        >
+          ※ 비밀번호: 8~15자의 영문 대/소문자, 숫자, 특수문자를 사용해 주세요.
+        </span>
       </div>
       <div className={divStyle}>
         <label className={infoTypeLabelStyle} htmlFor="passwordConfirm">
@@ -107,7 +116,7 @@ export const PasswordEditForm = () => {
             className={
               newPassword === passwordConfirm || passwordConfirm.length === 0
                 ? 'hidden'
-                : 'ml-4 text-red-500 text-xs'
+                : 'ml-4 text-red-500 text-xs hidden md:inline'
             }
           >
             ※ 비밀번호를 확인해주세요.
@@ -122,6 +131,15 @@ export const PasswordEditForm = () => {
           value={passwordConfirm}
           onChange={handlePasswordConfirmChange}
         />
+        <span
+          className={
+            newPassword === passwordConfirm || passwordConfirm.length === 0
+              ? 'hidden'
+              : 'my-1 text-red-500 text-xs md:hidden'
+          }
+        >
+          ※ 비밀번호를 확인해주세요.
+        </span>
       </div>
       <div className="relative mt-16 w-full md:w-1/2">
         <button

--- a/components/Form/PasswordEditForm.tsx
+++ b/components/Form/PasswordEditForm.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { editPassword } from '@/service/user';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const divStyle = 'my-4 inline-block w-full md:w-3/5';
 const infoTypeLabelStyle = 'block my-2';
@@ -11,6 +12,11 @@ export const PasswordEditForm = () => {
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [passwordConfirm, setPasswordConfirm] = useState('');
+  const [isFormValid, setIsFormValid] = useState(false);
+
+  const passwordRegExp =
+    /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
+  const isPasswordValid = passwordRegExp.test(newPassword);
 
   const router = useRouter();
 
@@ -30,16 +36,33 @@ export const PasswordEditForm = () => {
     setPasswordConfirm(e.target.value);
   };
 
-  const handleSaveButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+  useEffect(() => {
+    setIsFormValid(
+      currentPassword.length > 0 &&
+        newPassword.length > 0 &&
+        isPasswordValid &&
+        passwordConfirm.length > 0 &&
+        newPassword === passwordConfirm
+    );
+  }, [currentPassword, newPassword, passwordConfirm, isPasswordValid]);
+
+  const handleSaveButtonClick = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    // 저장 코드
-
-    router.replace('/user/edit');
+    const response = await editPassword(currentPassword, newPassword);
+    if (response.ok) {
+      window.alert('비밀번호가 변경되었습니다.');
+      router.replace('/user/edit');
+    } else {
+      window.alert('현재 비밀번호 인증에 실패하였습니다.');
+    }
   };
 
   return (
-    <form className="w-full flex flex-col items-center justify-center md:mt-6">
+    <form
+      onSubmit={handleSaveButtonClick}
+      className="w-full flex flex-col items-center justify-center md:mt-6"
+    >
       <div className={divStyle}>
         <label className={infoTypeLabelStyle} htmlFor="currentPassword">
           현재 비밀번호
@@ -57,6 +80,15 @@ export const PasswordEditForm = () => {
       <div className={divStyle}>
         <label className={infoTypeLabelStyle} htmlFor="newPassword">
           새 비밀번호
+          <span
+            className={
+              isPasswordValid || newPassword.length === 0
+                ? 'hidden'
+                : 'ml-4 text-red-500 text-xs'
+            }
+          >
+            ※ 비밀번호: 8~15자의 영문 대/소문자, 숫자, 특수문자를 사용해 주세요.
+          </span>
         </label>
         <input
           className={inputStyle}
@@ -71,6 +103,15 @@ export const PasswordEditForm = () => {
       <div className={divStyle}>
         <label className={infoTypeLabelStyle} htmlFor="passwordConfirm">
           새 비밀번호 확인
+          <span
+            className={
+              newPassword === passwordConfirm || passwordConfirm.length === 0
+                ? 'hidden'
+                : 'ml-4 text-red-500 text-xs'
+            }
+          >
+            ※ 비밀번호를 확인해주세요.
+          </span>
         </label>
         <input
           className={inputStyle}
@@ -84,8 +125,8 @@ export const PasswordEditForm = () => {
       </div>
       <div className="relative mt-16 w-full md:w-1/2">
         <button
-          className="text-xs md:text-base absolute left-[50%] translate-x-[-50%] rounded-3xl px-4 py-2 bg-main-color text-[white] font-bold border-none"
-          onClick={handleSaveButtonClick}
+          className="text-xs md:text-base absolute left-[50%] translate-x-[-50%] rounded-3xl px-4 py-2 bg-main-color text-[white] font-bold border-none disabled:opacity-70"
+          disabled={!isFormValid}
         >
           저장
         </button>

--- a/service/user.ts
+++ b/service/user.ts
@@ -1,5 +1,15 @@
 import { customFetch } from '@/utils/customFetch';
 
+export async function editPassword(password: string, newPassword: string) {
+  const response = await customFetch(
+    `/users/password/check/${password}/${newPassword}`,
+    {
+      method: 'POST',
+    }
+  );
+  return response;
+}
+
 export async function deleteUser({
   email,
   password,


### PR DESCRIPTION
## API 연결
- 비밀번호 수정(POST) : `/auth/users/password/check/{password}/{newPassword}`

## UI
<table> 
  <tr>
    <td valign="middle">
      <img width="170" align="middle" alt="image" src="https://github.com/YeolJyeongKong/fittering-FE/assets/94180099/faab68c3-59f9-46f4-a159-9bc6b0c9af1e">
     <img width="380" align="middle" alt="image" src="https://github.com/YeolJyeongKong/fittering-FE/assets/94180099/388c9afe-76a4-4b8b-bf09-f4f06d93cfca">
    </td>
    <td valign="middle">
      <img width="170" alt="image" src="https://github.com/YeolJyeongKong/fittering-FE/assets/94180099/7486389b-fa7c-4187-8bb0-9a0410661b44">
     </td>
  </tr>
  <tr>
    <td valign="middle" align="center">경고문구 - 모바일, PC web</td>
    <td valign="middle" align="center">올바르게 입력 시 저장 버튼 활성화</td>
  </tr>
</table>

- 비밀번호 형식에 맞지 않는 비밀번호를 입력하거나, 새 비밀번호와 새 비밀번호 확인이 일치하지 않을 경우 경고 문구를 띄우고 저장 버튼이 비활성화되도록 하였다.
- 모바일 화면에서는 경고 문구가 `input` 아래에, PC web 화면에서는 `label` 옆에 뜨도록 반응형을 적용하였다.
- 비밀번호 변경에 성공 시 '비밀번호가 변경되었습니다.' 라는 창을 띄우고 회원 정보 수정 페이지 `user/edit`로 이동하도록 하였다.