### PR TITLE
마이페이지 조회/수정 API 연결

### DIFF
--- a/app/(service)/user/layout.tsx
+++ b/app/(service)/user/layout.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import store from '@/store/store';
+import { Provider } from 'react-redux';
+
+export default function MyPageLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Provider store={store}>{children}</Provider>
+    </>
+  );
+}

--- a/app/(service)/user/layout.tsx
+++ b/app/(service)/user/layout.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import store from '@/store/store';
+import store, { persistor } from '@/store/store';
 import { Provider } from 'react-redux';
+import { PersistGate } from 'redux-persist/integration/react';
 
 export default function MyPageLayout({
   children,
@@ -10,7 +11,9 @@ export default function MyPageLayout({
 }) {
   return (
     <>
-      <Provider store={store}>{children}</Provider>
+      <Provider store={store}>
+        <PersistGate persistor={persistor}>{children}</PersistGate>
+      </Provider>
     </>
   );
 }

--- a/app/(service)/user/page.tsx
+++ b/app/(service)/user/page.tsx
@@ -1,15 +1,26 @@
+'use client';
+
 import FavoriteProducts from '@/components/FavoriteProducts';
 import RecentProducts from '@/components/MyPage/RecentProducts';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import { fetchMyPage } from '@/store/myPageAction';
+import { MyPage } from '@/types/user';
 import Link from 'next/link';
-import React from 'react';
+import React, { useEffect } from 'react';
 import MyPageCommon from '../../../components/MyPage/MyPageCommon';
 
 type Props = {};
-
 function MyPage(props: Props) {
+  const dispatch = useAppDispatch();
+  const myPage: MyPage = useAppSelector((state) => state.myPage);
+
+  useEffect(() => {
+    dispatch(fetchMyPage());
+  }, [dispatch]);
+
   return (
     <>
-      <MyPageCommon />
+      <MyPageCommon username={myPage.username ?? '- '} />
       <RecentProducts isPreview={true} />
       <FavoriteProducts isPreview={true} />
       <div className="mt-8 pt-6 border-t-[1.5px] border-nav-black text-center md:text-right">

--- a/components/Form/UserEditForm.tsx
+++ b/components/Form/UserEditForm.tsx
@@ -2,16 +2,20 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { useAppSelector } from '@/store/hooks';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { MyPage } from '@/types/user';
+import { editMyPage } from '@/service/user';
+import { myPageActions } from '@/store/myPageSlice';
 
 const divStyle = 'my-4 inline-block w-full md:w-3/5';
 const infoTypeLabelStyle = 'block my-2';
-const inputStyle = 'w-full border rounded-lg px-2 py-2.5 block mx-auto';
+const inputStyle =
+  'w-full border rounded-lg px-2 py-2.5 block mx-auto disabled:text-custom-gray-700';
 const birthDateInputStyle =
-  'w-2/3 lg:w-4/5 lg: border rounded-lg px-2 py-2.5 text-center md:text-right';
+  'w-2/3 lg:w-4/5 lg: border rounded-lg px-2 py-2.5 text-center md:text-right disabled:text-custom-gray-700';
 
 export const UserEditForm = () => {
+  const dispatch = useAppDispatch();
   const myPage: MyPage = useAppSelector((state) => state.myPage);
 
   const [username, setUsername] = useState(myPage.username ?? '-');
@@ -47,10 +51,25 @@ export const UserEditForm = () => {
     setDay(parseInt(e.target.value));
   };
 
-  const handleIsEditMode = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleIsEditMode = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
+    const updatedMyPage: MyPage = {
+      email: myPage.email,
+      username,
+      gender,
+      year,
+      month,
+      day,
+    };
     if (isEditMode) {
-      // 저장 코드
+      const response = await editMyPage(updatedMyPage);
+      if (response.ok) {
+        window.alert('회원 정보가 수정되었습니다.');
+        dispatch(myPageActions.setMyPage(updatedMyPage));
+        setIsEditMode(!isEditMode);
+      } else {
+        window.alert('회원 정보 수정에 실패하였습니다.');
+      }
     }
     setIsEditMode(!isEditMode);
   };
@@ -65,6 +84,7 @@ export const UserEditForm = () => {
           className={inputStyle}
           type="text"
           id="username"
+          value={username}
           placeholder={username}
           minLength={1}
           maxLength={20}
@@ -136,6 +156,7 @@ export const UserEditForm = () => {
                 className={birthDateInputStyle}
                 type="text"
                 id="year"
+                value={year}
                 placeholder={isNaN(year) ? '' : year.toString()}
                 onChange={handleYearChange}
                 minLength={4}
@@ -152,6 +173,7 @@ export const UserEditForm = () => {
                 className={birthDateInputStyle}
                 type="text"
                 id="month"
+                value={month}
                 placeholder={isNaN(month) ? '' : month.toString()}
                 onChange={handleMonthChange}
                 minLength={1}
@@ -168,6 +190,7 @@ export const UserEditForm = () => {
                 className={birthDateInputStyle}
                 type="text"
                 id="day"
+                value={day}
                 placeholder={isNaN(day) ? '' : day.toString()}
                 onChange={handleDayChange}
                 minLength={1}

--- a/components/Form/UserEditForm.tsx
+++ b/components/Form/UserEditForm.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import { useAppSelector } from '@/store/hooks';
+import { MyPage } from '@/types/user';
 
 const divStyle = 'my-4 inline-block w-full md:w-3/5';
 const infoTypeLabelStyle = 'block my-2';
@@ -10,11 +12,13 @@ const birthDateInputStyle =
   'w-2/3 lg:w-4/5 lg: border rounded-lg px-2 py-2.5 text-center md:text-right';
 
 export const UserEditForm = () => {
-  const [username, setUsername] = useState('열졍콩');
-  const [gender, setGender] = useState('F');
-  const [year, setYear] = useState(2023);
-  const [month, setMonth] = useState(7);
-  const [day, setDay] = useState(14);
+  const myPage: MyPage = useAppSelector((state) => state.myPage);
+
+  const [username, setUsername] = useState(myPage.username ?? '-');
+  const [gender, setGender] = useState(myPage.gender ?? '-');
+  const [year, setYear] = useState(myPage.year ?? 0);
+  const [month, setMonth] = useState(myPage.month ?? 0);
+  const [day, setDay] = useState(myPage.day ?? 0);
   const [isEditMode, setIsEditMode] = useState(false);
 
   const genderTextColor = isEditMode

--- a/components/MyPage/MyPageCommon.tsx
+++ b/components/MyPage/MyPageCommon.tsx
@@ -1,9 +1,15 @@
+'use client';
+
 import Image from 'next/image';
 import back from 'public/icon/left_black.svg';
 import UserEditLinks from './UserEditLinks';
 import MobileLogout from './MobileLogout';
 
-export default function MyPageCommon() {
+type Props = {
+  username: string;
+};
+
+export default function MyPageCommon({ username }: Props) {
   return (
     <>
       <div
@@ -23,7 +29,7 @@ export default function MyPageCommon() {
         </div>
         <div className="relative top-2 md:top-8">
           <span className="font-bold text-xl md:text-2xl">
-            열졍콩님, <br className="md:hidden" />
+            {`${username}님`}, <br className="md:hidden" />
             안녕하세요
           </span>
           <MobileLogout />

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^1.9.6",
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",
@@ -22,6 +23,7 @@
     "react": "18.2.0",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "18.2.0",
+    "react-redux": "^8.1.2",
     "react-slick": "^0.29.0",
     "slick-carousel": "^1.8.1",
     "tailwindcss": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",
     "@types/react-slick": "^0.23.10",
+    "@types/redux-persist": "^4.3.1",
     "autoprefixer": "10.4.14",
     "chart.js": "^4.4.0",
     "eslint": "8.44.0",
@@ -25,6 +26,7 @@
     "react-dom": "18.2.0",
     "react-redux": "^8.1.2",
     "react-slick": "^0.29.0",
+    "redux-persist": "^6.0.0",
     "slick-carousel": "^1.8.1",
     "tailwindcss": "3.3.2",
     "typescript": "5.1.6"

--- a/service/user.ts
+++ b/service/user.ts
@@ -1,4 +1,13 @@
+import { MyPage } from '@/types/user';
 import { customFetch } from '@/utils/customFetch';
+
+export async function getMyPage(): Promise<MyPage> {
+  const response = await customFetch('/users/mypage');
+  if (!response.ok) {
+    return {} as MyPage;
+  }
+  return response.json();
+}
 
 export async function editPassword(password: string, newPassword: string) {
   const response = await customFetch(

--- a/service/user.ts
+++ b/service/user.ts
@@ -9,6 +9,14 @@ export async function getMyPage(): Promise<MyPage> {
   return response.json();
 }
 
+export async function editMyPage(myPage: MyPage) {
+  const response = await customFetch('/users/mypage', {
+    method: 'POST',
+    body: JSON.stringify(myPage),
+  });
+  return response;
+}
+
 export async function editPassword(password: string, newPassword: string) {
   const response = await customFetch(
     `/users/password/check/${password}/${newPassword}`,

--- a/store/hooks.ts
+++ b/store/hooks.ts
@@ -1,0 +1,6 @@
+import { AppDispatch } from '@/store/store';
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import { RootState } from './store';
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/store/myPageAction.ts
+++ b/store/myPageAction.ts
@@ -1,0 +1,14 @@
+import { getMyPage } from '@/service/user';
+import { AnyAction, Dispatch } from '@reduxjs/toolkit';
+import { myPageActions } from './myPageSlice';
+
+export const fetchMyPage = () => {
+  return async (dispatch: Dispatch<AnyAction>) => {
+    const sendRequest = async () => {
+      const myPage = await getMyPage();
+      return myPage;
+    };
+    const myPage = await sendRequest();
+    dispatch(myPageActions.setMyPage(myPage));
+  };
+};

--- a/store/myPageSlice.ts
+++ b/store/myPageSlice.ts
@@ -1,0 +1,21 @@
+import { MyPage } from '@/types/user';
+import { createSlice } from '@reduxjs/toolkit';
+
+export const myPageSlice = createSlice({
+  name: 'myPage',
+  initialState: {} as MyPage,
+  reducers: {
+    setMyPage(state, action) {
+      state.email = action.payload.email;
+      state.username = action.payload.username;
+      state.gender = action.payload.gender;
+      state.year = action.payload.year;
+      state.month = action.payload.month;
+      state.day = action.payload.day;
+    },
+  },
+});
+
+export const myPageActions = myPageSlice.actions;
+
+export default myPageSlice.reducer;

--- a/store/rootReducer.ts
+++ b/store/rootReducer.ts
@@ -1,0 +1,16 @@
+import { combineReducers } from '@reduxjs/toolkit';
+import myPageReducer from './myPageSlice';
+import storage from 'redux-persist/lib/storage';
+import { persistReducer } from 'redux-persist';
+
+const persistConfig = {
+  key: 'root',
+  storage,
+  whitelist: ['myPage'],
+};
+
+const rootReducer = combineReducers({
+  myPage: myPageReducer,
+});
+
+export default persistReducer(persistConfig, rootReducer);

--- a/store/store.ts
+++ b/store/store.ts
@@ -1,7 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit';
+import myPage from './myPageSlice';
 
 export const store = configureStore({
-  reducer: {},
+  reducer: {
+    myPage,
+  },
 });
 
 export default store;

--- a/store/store.ts
+++ b/store/store.ts
@@ -1,0 +1,10 @@
+import { configureStore } from '@reduxjs/toolkit';
+
+export const store = configureStore({
+  reducer: {},
+});
+
+export default store;
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/store/store.ts
+++ b/store/store.ts
@@ -1,13 +1,14 @@
 import { configureStore } from '@reduxjs/toolkit';
-import myPage from './myPageSlice';
+import persistStore from 'redux-persist/lib/persistStore';
+import rootReducer from './rootReducer';
 
 export const store = configureStore({
-  reducer: {
-    myPage,
-  },
+  reducer: rootReducer
 });
 
 export default store;
+
+export const persistor = persistStore(store);
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,0 +1,8 @@
+export type MyPage = {
+  username: string;
+  email: string;
+  gender: string;
+  year: number;
+  month: number;
+  day: number;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -277,6 +277,13 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
+"@types/redux-persist@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@types/redux-persist/-/redux-persist-4.3.1.tgz#aa4c876859e0bea5155e5f7980e5b8c4699dc2e6"
+  integrity sha512-YkMnMUk+4//wPtiSTMfsxST/F9Gh9sPWX0LVxHuOidGjojHtMdpep2cYvQgfiDMnj34orXyZI+QJCQMZDlafKA==
+  dependencies:
+    redux-persist "*"
+
 "@types/scheduler@*":
   version "0.16.3"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.3.tgz#cef09e3ec9af1d63d2a6cc5b383a737e24e6dcf5"
@@ -2168,6 +2175,11 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+redux-persist@*, redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
 
 redux-thunk@^2.4.2:
   version "2.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,13 @@
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
+"@babel/runtime@^7.12.1", "@babel/runtime@^7.9.2":
+  version "7.23.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.1.tgz#72741dc4d413338a91dcb044a86f3c0bc402646d"
+  integrity sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/runtime@^7.20.7":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
@@ -202,6 +209,16 @@
     picocolors "^1.0.0"
     tslib "^2.5.0"
 
+"@reduxjs/toolkit@^1.9.6":
+  version "1.9.6"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.9.6.tgz#fc968b45fe5b17ff90932c4556960d9c1078365a"
+  integrity sha512-Gc4ikl90ORF4viIdAkY06JNUnODjKfGxZRwATM30EdHq8hLSVoSrwXne5dd739yenP5bJxAX7tLuOWK5RPGtrw==
+  dependencies:
+    immer "^9.0.21"
+    redux "^4.2.1"
+    redux-thunk "^2.4.2"
+    reselect "^4.1.8"
+
 "@rushstack/eslint-patch@^1.1.3":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.3.2.tgz#31b9c510d8cada9683549e1dbb4284cca5001faf"
@@ -213,6 +230,14 @@
   integrity sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==
   dependencies:
     tslib "^2.4.0"
+
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#dc1e9ded53375d37603c479cc12c693b0878aa2a"
+  integrity sha512-YIQtIg4PKr7ZyqNPZObpxfHsHEmuB8dXCxd6qVcGuQVDK2bpsF7bYNnBJ4Nn7giuACZg+WewExgrtAJ3XnA4Xw==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -256,6 +281,11 @@
   version "0.16.3"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.3.tgz#cef09e3ec9af1d63d2a6cc5b383a737e24e6dcf5"
   integrity sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==
+
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
 "@typescript-eslint/parser@^5.42.0":
   version "5.60.1"
@@ -1336,6 +1366,13 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
@@ -1350,6 +1387,11 @@ ignore@^5.2.0:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
+
+immer@^9.0.21:
+  version "9.0.21"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
+  integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -2073,10 +2115,27 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-is@^16.13.1:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^18.0.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-redux@^8.1.2:
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-8.1.2.tgz#9076bbc6b60f746659ad6d51cb05de9c5e1e9188"
+  integrity sha512-xJKYI189VwfsFc4CJvHqHlDrzyFTY/3vZACbE+rr/zQ34Xx1wQfB4OTOSeOSNrF6BDVe8OOdxIrAnMGXA3ggfw==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    "@types/use-sync-external-store" "^0.0.3"
+    hoist-non-react-statics "^3.3.2"
+    react-is "^18.0.0"
+    use-sync-external-store "^1.0.0"
 
 react-slick@^0.29.0:
   version "0.29.0"
@@ -2110,10 +2169,27 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+redux-thunk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.2.tgz#b9d05d11994b99f7a91ea223e8b04cf0afa5ef3b"
+  integrity sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==
+
+redux@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
+  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
 regenerator-runtime@^0.13.11:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
+  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
 
 regexp.prototype.flags@^1.4.3:
   version "1.5.0"
@@ -2123,6 +2199,11 @@ regexp.prototype.flags@^1.4.3:
     call-bind "^1.0.2"
     define-properties "^1.2.0"
     functions-have-names "^1.2.3"
+
+reselect@^4.1.8:
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.8.tgz#3f5dc671ea168dccdeb3e141236f69f02eaec524"
+  integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
 
 resize-observer-polyfill@^1.5.0:
   version "1.5.1"
@@ -2527,6 +2608,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+use-sync-external-store@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 util-deprecate@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## API 연결
- 마이페이지 조회(GET) : `/auth/users/mypage`
- 마이페이지 수정(POST) : `/auth/users/mypage`

## 리덕스 상태 관리
마이페이지 조회 API를 통해 불러온 회원 정보는

1. 마이페이지의 `"${username}님 안녕하세요"` 문구
2. 마이페이지에서 `회원정보 수정` 버튼을 눌렀을 때 나오는 회원 정보 수정 페이지의 폼에서 `input`의 `placeholder`와 `value`

에서 사용되는데

회원 정보 수정 페이지는 마이페이지에서 들어가므로, 마이페이지 조회 API를 마이페이지와 회원 정보 수정 페이지 모두에서 호출하기보다는 마이페이지에서만 호출한 뒤 해당 정보를 회원 정보 수정 페이지에서도 사용할 수 있도록 회원 정보를 전역 상태로 두었다.

[관련 블로그](https://velog.io/@thumbzzero/Fittering-%EA%B0%9C%EB%B0%9C-%EA%B8%B0%EB%A1%9D-%EB%A6%AC%EB%8D%95%EC%8A%A4-%ED%88%B4%ED%82%B7-%EC%82%AC%EC%9A%A9-%EA%B4%80%EB%A0%A8-%ED%8A%B8%EB%9F%AC%EB%B8%94-%EC%8A%88%ED%8C%85)

## redux-persist
회원 정보 수정 페이지에서 새로고침 시 API 응답 결과로 업데이트되기 전의 초기 상태로 돌아가 `placeholder`에 유저 정보가 올바르게 표시되지 않는 문제가 있었고, 이를 해결하기 위해 `redux-persist` 라이브러리를 사용하였다.

[관련 블로그](https://velog.io/@thumbzzero/Fittering-%EA%B0%9C%EB%B0%9C-%EA%B8%B0%EB%A1%9D-%EB%A6%AC%EB%8D%95%EC%8A%A4-%EC%83%88%EB%A1%9C%EA%B3%A0%EC%B9%A8-%EC%83%81%ED%83%9C-%EC%B4%88%EA%B8%B0%ED%99%94-%EC%9D%B4%EC%8A%88)

