### PR TITLE
체형 정보 조회/수정 API 연결

### DIFF
--- a/app/(service)/user/mysize/edit/page.tsx
+++ b/app/(service)/user/mysize/edit/page.tsx
@@ -2,14 +2,12 @@ import MobileSection from '@/components/MobileSection';
 import LineSection from '@/components/LineSection';
 import EditForm from '@/components/MyPage/MySize/EditForm';
 import GuidelinePic from '@/components/MyPage/MySize/GuidelinePic';
-import { getMySize } from '@/service/mysize';
 
 import React from 'react';
 
 type Props = {};
 
 async function MySizeEditPage(props: Props) {
-  const mySize = await getMySize();
   return (
     <>
       <LineSection
@@ -19,7 +17,7 @@ async function MySizeEditPage(props: Props) {
       <MobileSection sectionName="내 맞춤 정보 설정" />
       <div className="flex flex-col gap-8 md:gap-12 w-full md:flex-row md:portrait:flex-col">
         <GuidelinePic />
-        <EditForm mySize={mySize} />
+        <EditForm />
       </div>
     </>
   );

--- a/app/(service)/user/mysize/page.tsx
+++ b/app/(service)/user/mysize/page.tsx
@@ -17,7 +17,6 @@ function MySizePage(props: Props) {
       <MobileSection sectionName="내 맞춤 정보 설정" />
       <div className="flex flex-col gap-8 md:gap-12 w-full md:flex-row md:portrait:flex-col">
         <GuidelinePic /> 
-        {/* @ts-expect-error Server Component */}
         <MySizeInfo />
       </div>
       <EditButton />

--- a/components/MyPage/MySize/EditForm.tsx
+++ b/components/MyPage/MySize/EditForm.tsx
@@ -1,33 +1,109 @@
 'use client';
 
-import { MySize } from '@/service/mysize';
+import { editMySize, MySize } from '@/service/mysize';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import { mySizeActions } from '@/store/mySizeSlice';
+import { useState } from 'react';
 import EditFormInput from './EditFormInput';
+import { useRouter } from 'next/navigation';
 
-type Props = {
-  mySize: MySize;
-};
+type Props = {};
 
-export default function EditForm({ mySize }: Props) {
+export default function EditForm(props: Props) {
+  const router = useRouter();
+  const dispatch = useAppDispatch();
+  const mySize: MySize = useAppSelector((state) => state.mySize);
+
+  const [height, setHeight] = useState(mySize.height ?? null);
+  const [weight, setWeight] = useState(mySize.weight ?? null);
+  const [arm, setArm] = useState(mySize.arm ?? null);
+  const [leg, setLeg] = useState(mySize.leg ?? null);
+  const [shoulder, setShoulder] = useState(mySize.shoulder ?? null);
+  const [waist, setWaist] = useState(mySize.waist ?? null);
+  const [chest, setChest] = useState(mySize.chest ?? null);
+  const [thigh, setThigh] = useState(mySize.thigh ?? null);
+  const [hip, setHip] = useState(mySize.hip ?? null);
+
+  const handleEditMySize = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+
+    if (height === null || weight === null) {
+      window.alert('키와 몸무게는 필수 입력 사항입니다.');
+      return;
+    }
+
+    const updatedMySize: MySize = {
+      height,
+      weight,
+      arm,
+      leg,
+      shoulder,
+      waist,
+      chest,
+      thigh,
+      hip,
+    };
+
+    const response = await editMySize(updatedMySize);
+    if (response.ok) {
+      window.alert('체형 정보가 수정되었습니다.');
+      dispatch(mySizeActions.setMySize(updatedMySize));
+      router.replace('/user/mysize');
+    } else {
+      window.alert('체형 정보 수정에 실패하였습니다.');
+    }
+  };
+
   return (
     <div className="flex-1 w-full h-full">
       <div className="font-semibold pb-6">열졍콩님의 체형</div>
 
-      <div className="flex flex-col md:flex-row md:gap-12">
+      <form className="flex flex-col md:flex-row md:gap-12">
         <div className="flex-1">
-          <EditFormInput bodyType="height" size={mySize.height} />
-          <EditFormInput bodyType="weight" size={mySize.weight} />
-          <EditFormInput bodyType="arm" size={mySize.arm} />
-          <EditFormInput bodyType="leg" size={mySize.leg} />
-          <EditFormInput bodyType="shoulder" size={mySize.shoulder} />
+          <EditFormInput
+            bodyType="height"
+            size={mySize.height}
+            setSize={setHeight}
+          />
+          <EditFormInput
+            bodyType="weight"
+            size={mySize.weight}
+            setSize={setWeight}
+          />
+          <EditFormInput bodyType="arm" size={mySize.arm} setSize={setArm} />
+          <EditFormInput bodyType="leg" size={mySize.leg} setSize={setLeg} />
+          <EditFormInput
+            bodyType="shoulder"
+            size={mySize.shoulder}
+            setSize={setShoulder}
+          />
         </div>
 
         <div className="flex-1">
-          <EditFormInput bodyType="chest" size={mySize.chest} />
-          <EditFormInput bodyType="waist" size={mySize.waist} />
-          <EditFormInput bodyType="thigh" size={mySize.thigh} />
-          <EditFormInput bodyType="hip" size={mySize.hip} />
+          <EditFormInput
+            bodyType="chest"
+            size={mySize.chest}
+            setSize={setChest}
+          />
+          <EditFormInput
+            bodyType="waist"
+            size={mySize.waist}
+            setSize={setWaist}
+          />
+          <EditFormInput
+            bodyType="thigh"
+            size={mySize.thigh}
+            setSize={setThigh}
+          />
+          <EditFormInput bodyType="hip" size={mySize.hip} setSize={setHip} />
         </div>
-      </div>
+      </form>
+      <button
+        className="w-full md:w-[10rem] mt-8 md:mt-12 py-2 block mx-auto bg-main-color text-white rounded-lg"
+        onClick={handleEditMySize}
+      >
+        저장
+      </button>
     </div>
   );
 }

--- a/components/MyPage/MySize/EditFormInput.tsx
+++ b/components/MyPage/MySize/EditFormInput.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { useState } from 'react';
+
 type Props = {
   bodyType:
     | 'height'
@@ -10,6 +14,7 @@ type Props = {
     | 'thigh'
     | 'hip';
   size: number | null;
+  setSize: React.Dispatch<React.SetStateAction<number | null>>;
 };
 
 const bodyTypeEn2Ko = {
@@ -24,7 +29,14 @@ const bodyTypeEn2Ko = {
   hip: '엉덩이 둘레',
 };
 
-export default function EditFormInput({ bodyType, size }: Props) {
+export default function EditFormInput({ bodyType, size, setSize }: Props) {
+  const [value, setValue] = useState(size?.toString() ?? '');
+
+  const handleSizeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSize(parseInt(e.target.value));
+    setValue(e.target.value);
+  };
+
   return (
     <div className="w-full relative h-8 md:h-16">
       <label>
@@ -34,10 +46,12 @@ export default function EditFormInput({ bodyType, size }: Props) {
         {bodyTypeEn2Ko[bodyType]}
       </label>
       <input
-        className="absolute right-8 w-[25%] md:w-[30%] lg:w-[40%] landscape:w-[35%] lg:landscape:w-[40%]  border bg-transparent text-right px-2"
+        className="absolute right-8 w-[25%] md:w-[30%] lg:w-[40%] landscape:w-[35%] lg:landscape:w-[40%] border bg-transparent text-right px-2"
         type="number"
         inputMode="numeric"
+        onChange={handleSizeChange}
         placeholder={size !== null ? size.toString() : ''}
+        value={value}
         min={0}
         max={300}
       />

--- a/components/MyPage/MySize/MySizeInfo.tsx
+++ b/components/MyPage/MySize/MySizeInfo.tsx
@@ -1,12 +1,22 @@
-import { getMySize } from '@/service/mysize';
+'use client';
+
+import { MySize } from '@/service/mysize';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import { fetchMySize } from '@/store/mySizeAction';
+import { useEffect } from 'react';
 
 const tableStyle =
   'table-fixed w-full h-1/2 md:w-1/2 md:h-full md:border-spacing-y-8 md:align-top';
 const trStyle = 'h-8 md:h-16';
 const sizeStyle = 'text-main-color font-semibold text-lg pr-2';
 
-export default async function MySizeInfo() {
-  const mySize = await getMySize();
+export default function MySizeInfo() {
+  const dispatch = useAppDispatch();
+  const mySize: MySize = useAppSelector((state) => state.mySize);
+
+  useEffect(() => {
+    dispatch(fetchMySize());
+  }, [dispatch]);
 
   return (
     <div className="flex-1 w-full h-full">
@@ -17,45 +27,35 @@ export default async function MySizeInfo() {
             <tr className={trStyle}>
               <td className="text-left align-top">‧ 키</td>
               <td className="text-right align-top">
-                <span className={sizeStyle}>
-                  {mySize.height !== null ? mySize.height : '-'}
-                </span>
+                <span className={sizeStyle}>{mySize.height ?? '-'}</span>
                 cm
               </td>
             </tr>
             <tr className={trStyle}>
               <td className="text-left align-top">‧ 몸무게</td>
               <td className="text-right align-top">
-                <span className={sizeStyle}>
-                  {mySize.weight !== null ? mySize.weight : '-'}
-                </span>
+                <span className={sizeStyle}>{mySize.weight ?? '-'}</span>
                 kg
               </td>
             </tr>
             <tr className={trStyle}>
               <td className="text-left align-top">‧ 팔 길이</td>
               <td className="text-right align-top">
-                <span className={sizeStyle}>
-                  {mySize.arm !== null ? mySize.arm : '-'}
-                </span>
+                <span className={sizeStyle}>{mySize.arm ?? '-'}</span>
                 cm
               </td>
             </tr>
             <tr className={trStyle}>
               <td className="text-left align-top">‧ 다리 길이</td>
               <td className="text-right align-top">
-                <span className={sizeStyle}>
-                  {mySize.leg !== null ? mySize.leg : '-'}
-                </span>
+                <span className={sizeStyle}>{mySize.leg ?? '-'}</span>
                 cm
               </td>
             </tr>
             <tr className={trStyle}>
               <td className="text-left align-top">‧ 어깨 너비</td>
               <td className="text-right align-top">
-                <span className={sizeStyle}>
-                  {mySize.shoulder !== null ? mySize.shoulder : '-'}
-                </span>
+                <span className={sizeStyle}>{mySize.shoulder ?? '-'}</span>
                 cm
               </td>
             </tr>
@@ -66,36 +66,28 @@ export default async function MySizeInfo() {
             <tr className={trStyle}>
               <td className="text-left align-top">‧ 가슴 둘레</td>
               <td className="text-right align-top">
-                <span className={sizeStyle}>
-                  {mySize.chest !== null ? mySize.chest : '-'}
-                </span>
+                <span className={sizeStyle}>{mySize.chest ?? '-'}</span>
                 cm
               </td>
             </tr>
             <tr className={trStyle}>
               <td className="text-left align-top">‧ 허리 둘레</td>
               <td className="text-right align-top">
-                <span className={sizeStyle}>
-                  {mySize.waist !== null ? mySize.waist : '-'}
-                </span>
+                <span className={sizeStyle}>{mySize.waist ?? '-'}</span>
                 cm
               </td>
             </tr>
             <tr className={trStyle}>
               <td className="text-left align-top">‧ 허벅지 둘레</td>
               <td className="text-right align-top">
-                <span className={sizeStyle}>
-                  {mySize.thigh !== null ? mySize.thigh : '-'}
-                </span>
+                <span className={sizeStyle}>{mySize.thigh ?? '-'}</span>
                 cm
               </td>
             </tr>
             <tr className={trStyle}>
               <td className="text-left align-top">‧ 엉덩이 둘레</td>
               <td className="text-right align-top">
-                <span className={sizeStyle}>
-                  {mySize.hip !== null ? mySize.hip : '-'}
-                </span>
+                <span className={sizeStyle}>{mySize.hip ?? '-'}</span>
                 cm
               </td>
             </tr>

--- a/service/mysize.ts
+++ b/service/mysize.ts
@@ -20,6 +20,14 @@ export async function getMySize(): Promise<MySize> {
   return response.json();
 }
 
+export async function editMySize(mySize: MySize) {
+  const response = await customFetch('/users/mysize', {
+    method: 'POST',
+    body: JSON.stringify(mySize),
+  });
+  return response;
+}
+
 export async function getSilhouetteImage(
   type: 'FRONT' | 'SIDE',
   formData: FormData

--- a/service/mysize.ts
+++ b/service/mysize.ts
@@ -1,6 +1,4 @@
 import { customFetch } from '@/utils/customFetch';
-import { readFile } from 'fs/promises';
-import path from 'path';
 
 export type MySize = {
   height: number | null;
@@ -15,9 +13,11 @@ export type MySize = {
 };
 
 export async function getMySize(): Promise<MySize> {
-  // 더미 데이터 읽어옴
-  const filePath = path.join(process.cwd(), 'data', 'mysize.json');
-  return readFile(filePath, 'utf-8').then<MySize>(JSON.parse);
+  const response = await customFetch('/users/mysize');
+  if (!response.ok) {
+    return {} as MySize;
+  }
+  return response.json();
 }
 
 export async function getSilhouetteImage(

--- a/store/mySizeAction.ts
+++ b/store/mySizeAction.ts
@@ -1,0 +1,14 @@
+import { getMySize } from '@/service/mysize';
+import { AnyAction, Dispatch } from '@reduxjs/toolkit';
+import { mySizeActions } from './mySizeSlice';
+
+export const fetchMySize = () => {
+  return async (dispatch: Dispatch<AnyAction>) => {
+    const sendRequest = async () => {
+      const mySize = await getMySize();
+      return mySize;
+    };
+    const mySize = await sendRequest();
+    dispatch(mySizeActions.setMySize(mySize));
+  };
+};

--- a/store/mySizeSlice.ts
+++ b/store/mySizeSlice.ts
@@ -1,0 +1,24 @@
+import { MySize } from '@/service/mysize';
+import { createSlice } from '@reduxjs/toolkit';
+
+export const mySizeSlice = createSlice({
+  name: 'mySize',
+  initialState: {} as MySize,
+  reducers: {
+    setMySize(state, action) {
+      state.height = action.payload.height;
+      state.weight = action.payload.weight;
+      state.arm = action.payload.arm;
+      state.leg = action.payload.leg;
+      state.shoulder = action.payload.shoulder;
+      state.waist = action.payload.waist;
+      state.chest = action.payload.chest;
+      state.thigh = action.payload.thigh;
+      state.hip = action.payload.hip;
+    },
+  },
+});
+
+export const mySizeActions = mySizeSlice.actions;
+
+export default mySizeSlice.reducer;

--- a/store/rootReducer.ts
+++ b/store/rootReducer.ts
@@ -1,16 +1,18 @@
 import { combineReducers } from '@reduxjs/toolkit';
 import myPageReducer from './myPageSlice';
+import mySizeReducer from './mySizeSlice';
 import storage from 'redux-persist/lib/storage';
 import { persistReducer } from 'redux-persist';
 
 const persistConfig = {
   key: 'root',
   storage,
-  whitelist: ['myPage'],
+  whitelist: ['myPage', 'mySize'],
 };
 
 const rootReducer = combineReducers({
   myPage: myPageReducer,
+  mySize: mySizeReducer,
 });
 
 export default persistReducer(persistConfig, rootReducer);

--- a/store/store.ts
+++ b/store/store.ts
@@ -3,7 +3,9 @@ import persistStore from 'redux-persist/lib/persistStore';
 import rootReducer from './rootReducer';
 
 export const store = configureStore({
-  reducer: rootReducer
+  reducer: rootReducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({ serializableCheck: false }),
 });
 
 export default store;


### PR DESCRIPTION
## API 연결
- 체형 정보 조회(GET) : `/auth/users/mysize`
- 체형 정보 수정(POST) : `/auth/users/mysize`

## 체형 정보 리덕스 스토어에 저장
체형 정보 조회 API를 통해 불러온 체형 정보는

1. 내 맞춤 정보(체형) 조회 페이지
2. 내 맞춤 정보(체형) 조회 페이지에서 `수정` - `직접 입력하기` 버튼을 눌렀을 때 나오는 내 맞춤 정보(체형) 정보 수정 페이지의 폼에서 `input`의 `placeholder`와 `initial value`

에서 사용되므로 체형 정보를 전역 상태로 두었다.

## 리덕스 관련 오류 해결
```
A non-serializable value was detected in an action, in the path: `type`
```
위의 오류를 [해당 글](https://guiyomi.tistory.com/116)을 참고하여 해결하였다.