### PR TITLE
체형 스마트 분석 기능 개발

### DIFF
--- a/app/(service)/user/mysize/smart_analysis/page.tsx
+++ b/app/(service)/user/mysize/smart_analysis/page.tsx
@@ -1,6 +1,6 @@
 import MobileSection from '@/components/MobileSection';
 import Guideline from '@/components/MyPage/MySize/Guideline';
-import SmartAnalysisPhotoSubmitForm from '@/components/MyPage/MySize/SmartAnalysisPhotoSubmitForm';
+import SmartAnalysisForm from '@/components/MyPage/MySize/SmartAnalysisForm';
 import React from 'react';
 import LineSection from '../../../../../components/LineSection';
 import Section from '../../../../../components/Section';
@@ -16,10 +16,7 @@ function SmartAnalysisPage(props: Props) {
       />
       <MobileSection sectionName="내 맞춤 정보 설정" />
       <Section sectionName="스마트 분석" />
-      <div className="flex flex-col md:flex-row gap-4 mt-2">
-        <SmartAnalysisPhotoSubmitForm photoType="FRONT" />
-        <SmartAnalysisPhotoSubmitForm photoType="SIDE" />
-      </div>
+      <SmartAnalysisForm />
       <Guideline />
     </>
   );

--- a/components/MyPage/MySize/EditFormInput.tsx
+++ b/components/MyPage/MySize/EditFormInput.tsx
@@ -33,7 +33,7 @@ export default function EditFormInput({ bodyType, size, setSize }: Props) {
   const [value, setValue] = useState(size?.toString() ?? '');
 
   const handleSizeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSize(parseInt(e.target.value));
+    setSize(Number(e.target.value));
     setValue(e.target.value);
   };
 

--- a/components/MyPage/MySize/SmartAnalysisForm.tsx
+++ b/components/MyPage/MySize/SmartAnalysisForm.tsx
@@ -19,6 +19,14 @@ export default function SmartAnalysisForm() {
   const router = useRouter();
 
   useEffect(() => {
+    if (mySize.height === null || mySize.weight === null) {
+      window.alert('스마트 분석 기능을 이용하려면 키와 몸무게를 입력해주세요.');
+      router.replace('/user/mysize/edit');
+      return;
+    }
+  }, [mySize.height, mySize.weight, router]);
+
+  useEffect(() => {
     setIsPrepared(frontImage !== null && sideImage !== null);
   }, [frontImage, sideImage]);
 

--- a/components/MyPage/MySize/SmartAnalysisForm.tsx
+++ b/components/MyPage/MySize/SmartAnalysisForm.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import SmartAnalysisPhotoSubmitForm from '@/components/MyPage/MySize/SmartAnalysisPhotoSubmitForm';
+import { MySize, smartAnalysis } from '@/service/mysize';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { mySizeActions } from '@/store/mySizeSlice';
+
+export default function SmartAnalysisForm() {
+  const [isPrepared, setIsPrepared] = useState(false);
+  const [frontImage, setFrontImage] = useState<string | null>(null);
+  const [sideImage, setSideImage] = useState<string | null>(null);
+
+  const dispatch = useAppDispatch();
+  const mySize: MySize = useAppSelector((state) => state.mySize);
+  const user = useAppSelector((state) => state.myPage);
+
+  const router = useRouter();
+
+  useEffect(() => {
+    setIsPrepared(frontImage !== null && sideImage !== null);
+  }, [frontImage, sideImage]);
+
+  const handleSmartAnalysis = async (
+    e: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    const response = await smartAnalysis({
+      front: frontImage?.split('/')[4] ?? '',
+      side: sideImage?.split('/')[4] ?? '',
+      height: mySize.height ?? 0,
+      weight: mySize.weight ?? 0,
+      sex: user.gender,
+    });
+
+    if (response.ok) {
+      window.alert(
+        '스마트 분석을 완료하였습니다. 분석 결과를 확인 후 저장해주세요.'
+      );
+      const data: MySize = await response.json();
+      dispatch(mySizeActions.setMySize(data));
+      router.replace('/user/mysize/edit');
+    } else {
+      window.alert('스마트 분석에 실패하였습니다.');
+      setFrontImage(null);
+      setSideImage(null);
+      setIsPrepared(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="flex flex-col md:flex-row gap-4 mt-2">
+        <SmartAnalysisPhotoSubmitForm
+          photoType="FRONT"
+          imageUrl={frontImage}
+          setImageUrl={setFrontImage}
+        />
+        <SmartAnalysisPhotoSubmitForm
+          photoType="SIDE"
+          imageUrl={sideImage}
+          setImageUrl={setSideImage}
+        />
+      </div>
+      {isPrepared && (
+        <button
+          className="w-full md:w-[10rem] mt-8 md:mt-12 py-2 block mx-auto bg-main-color text-white rounded-lg"
+          onClick={handleSmartAnalysis}
+        >
+          분석하기
+        </button>
+      )}
+    </>
+  );
+}

--- a/components/MyPage/MySize/SmartAnalysisPhotoSubmitForm.tsx
+++ b/components/MyPage/MySize/SmartAnalysisPhotoSubmitForm.tsx
@@ -3,15 +3,16 @@
 import { getSilhouetteImage } from '@/service/mysize';
 import Image from 'next/image';
 import plus from 'public/icon/plus_white.svg';
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 
 type Props = {
   photoType: 'FRONT' | 'SIDE';
+  imageUrl : string | null;
+  setImageUrl : React.Dispatch<React.SetStateAction<string | null>>;
 };
 
-export default function SmartAnalysisPhotoSubmitForm({ photoType }: Props) {
+export default function SmartAnalysisPhotoSubmitForm({ photoType, imageUrl, setImageUrl }: Props) {
   const imageInput = useRef<HTMLInputElement>(null);
-  const [imageUrl, setImageUrl] = useState<string | null>(null);
 
   const handleImageInputClick = () => {
     imageInput.current?.click();

--- a/service/mysize.ts
+++ b/service/mysize.ts
@@ -12,6 +12,14 @@ export type MySize = {
   hip: number | null;
 };
 
+export type smartAnalysisRequestBody = {
+  front: string;
+  side: string;
+  height: number;
+  weight: number;
+  sex: string;
+};
+
 export async function getMySize(): Promise<MySize> {
   const response = await customFetch('/users/mysize');
   if (!response.ok) {
@@ -45,4 +53,12 @@ export async function getSilhouetteImage(
   }
   const data: { url: string } = await response.json();
   return data.url;
+}
+
+export async function smartAnalysis(body: smartAnalysisRequestBody) {
+  const response = await customFetch('/users/recommendation/measurement', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  return response;
 }


### PR DESCRIPTION
## API 연결
- 체형 스마트 분석(POST) : `/auth/users/recommendation/measurement`

## 기타
- 필수정보인 키, 몸무게가 입력이 안 되어 있는 유저의 경우 경고창을 띄우고 체형 정보 수정 페이지로 Redirect 함
- 체형 스마트 분석 API 호출 시에 체형 실루엣 이미지 제공 API `/users/mysize/silhouette?type=${type}`에서 응답으로 받은 이미지 `URL`에서 파일명만 파싱하여 `Request body`로 넣어줌
- 정면/측면 사진을 모두 등록해야 분석하기 버튼이 뜨도록 함
```ts
/* Request body */
{
  front: string;  /*  '/users/mysize/silhouette?type=FRONT'로 호출한 응답  */
  side: string;  /*  '/users/mysize/silhouette?type=SIDE'로 호출한 응답  */
  height: number;
  weight: number;
  sex: string;
};
```
- 스마트 분석 성공 시 체형 정보 수정 페이지로 Redirect하고, 분석 결과를 `input`의 `value`로 미리 작성해두어 사용자가 수정하고 싶은 부분은 수정한 후 저장하여 결과를 반영할 수 있도록 함
### 참고
- 체형 분석 기능은 아래와 같은 워크 플로우를 따르게 된다.
<img width="1047" alt="image" src="https://github.com/YeolJyeongKong/fittering-FE/assets/94180099/57d054c4-e4e2-4639-9fad-5c3511bdad76">


## 버그 수정
- 체형 정보 수정 페이지의 입력값을 소수점까지 반영해야 하므로 숫자형으로 변환해야 하는데, 정수로 변환하는 코드가 있어 해당 부분을 수정함
```ts
setSize(parseInt(e.target.value));   // 수정 전
setSize(Number(e.target.value));   // 수정 후
```