### PR TITLE
연관 검색어 조회 API fetch 함수 추가

### DIFF
--- a/service/search.ts
+++ b/service/search.ts
@@ -1,0 +1,22 @@
+import { customFetch } from '@/utils/customFetch';
+
+export type Keywords = {
+  products: {
+    id: number;
+    name: string;
+    image: string;
+  }[];
+  malls: {
+    id: number;
+    name: string;
+    image: string;
+  }[];
+};
+
+export async function getSearchKeywords(keyword: string): Promise<Keywords> {
+  const response = await customFetch(`/search/${keyword}`);
+  if (!response.ok) {
+    return { products: [], malls: [] };
+  }
+  return await response.json();
+}


### PR DESCRIPTION
## 연관 검색어 조회 API fetch 함수 추가
- 연관 검색어 조회(GET) : `/auth/search/{keyword}` API를 fetch 하는 함수 추가
```ts
/* 응답 타입 */

export type Keywords = {
  products: {
    id: number;
    name: string;
    image: string;
  }[];
  malls: {
    id: number;
    name: string;
    image: string;
  }[];
};
```
- `Keywords` 타입으로 리턴