### PR TITLE
배포 에러 해결: import문 삭제

### DIFF
--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -4,7 +4,6 @@ import Image from 'next/image';
 import search from '/public/icon/search_green.svg';
 import { useState } from 'react';
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
-import SearchKeywords from './SearchKeywords';
 
 export default function SearchBar() {
   const pathname = usePathname();


### PR DESCRIPTION
## 배포 에러 해결: import문 삭제
<img width="796" alt="image" src="https://github.com/YeolJyeongKong/fittering-FE/assets/94180099/35cebcb1-7732-468f-9ab9-3f07571741b5">

- 아직 repository에 반영이 안 된 파일이 import 되어 있어 배포 실패 -> 해당 import문 삭제