### PR TITLE
연관 검색어 조회 기능 개발

### DIFF
--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -45,7 +45,11 @@ export default function SearchBar() {
 
   const handleSearch = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    router.push(`/search?keyword=${searchInput}`);
+    if (searchInput) {
+      router.push(`/search?keyword=${searchInput}`);
+      setSearchInput('');
+      setKeyword('');
+    }
   };
 
   return (
@@ -71,10 +75,14 @@ export default function SearchBar() {
         <SearchKeywords
           keyword={keyword}
           keywords={{ type: 'malls', data: keywords.malls }}
+          setSearchInput={setSearchInput}
+          setKeyword={setKeyword}
         />
         <SearchKeywords
           keyword={keyword}
           keywords={{ type: 'products', data: keywords.products }}
+          setSearchInput={setSearchInput}
+          setKeyword={setKeyword}
         />
       </div>
     </div>

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -2,20 +2,44 @@
 
 import Image from 'next/image';
 import search from '/public/icon/search_green.svg';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
+import { getSearchKeywords, Keywords } from '@/service/search';
 
 export default function SearchBar() {
   const pathname = usePathname();
   const searchParam = useSearchParams();
-
-  const [keyword, setKeyword] = useState(
-    pathname === '/search' ? searchParam.get('keyword') ?? '' : ''
-  );
   const router = useRouter();
 
+  const [searchInput, setSearchInput] = useState(
+    pathname === '/search' ? searchParam.get('keyword') ?? '' : ''
+  );
+  const [keyword, setKeyword] = useState('');
+  const [keywords, setKeywords] = useState<Keywords>({
+    products: [],
+    malls: [],
+  });
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setKeyword(searchInput);
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  useEffect(() => {
+    async function fetchSearchKeywords() {
+      const keywords = await getSearchKeywords(keyword);
+      setKeywords(keywords);
+    }
+
+    if (keyword) fetchSearchKeywords();
+    else setKeywords({ products: [], malls: [] });
+  }, [keyword]);
+
   const handleKeywordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setKeyword(e.target.value);
+    setSearchInput(e.target.value);
   };
 
   const handleSearch = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -26,19 +50,19 @@ export default function SearchBar() {
   return (
     <div className="relative w-[78%] xs:w-[80%] md:w-[50%]">
       <form onSubmit={handleSearch} className="w-11/12 md:w-full">
-        <input
-          className="border-[0.5px] bg-custom-gray-50 rounded right-0 w-full h-9 md:h-10 pl-4 text-xs absolute top-[50%] translate-y-[-50%]"
-          type="text"
-          placeholder="검색어를 입력하세요."
-          onChange={handleKeywordChange}
-          value={keyword}
-        />
-        <button
-          className="absolute right-0 md:right-1 top-[50%] translate-y-[-50%] md:r-1/12"
-          aria-label="검색하기"
-        >
-          <Image src={search} alt="검색 버튼" aria-hidden={true} />
-        </button>
+          <input
+            className="border-[0.5px] bg-custom-gray-50 rounded right-0 w-full h-9 md:h-10 pl-4 text-xs absolute top-[50%] translate-y-[-50%]"
+            type="text"
+            placeholder="검색어를 입력하세요."
+            onChange={handleKeywordChange}
+            value={searchInput}
+          />
+          <button
+            className="absolute right-0 md:right-1 top-[50%] translate-y-[-50%] md:r-1/12"
+            aria-label="검색하기"
+          >
+            <Image src={search} alt="검색 버튼" aria-hidden={true} />
+          </button>
       </form>
     </div>
   );

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -45,7 +45,7 @@ export default function SearchBar() {
 
   const handleSearch = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    router.push(`/search?keyword=${keyword}`);
+    router.push(`/search?keyword=${searchInput}`);
   };
 
   return (

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import search from '/public/icon/search_green.svg';
 import { useState, useEffect } from 'react';
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
+import SearchKeywords from './SearchKeywords';
 import { getSearchKeywords, Keywords } from '@/service/search';
 
 export default function SearchBar() {
@@ -48,22 +49,34 @@ export default function SearchBar() {
   };
 
   return (
-    <div className="relative w-[78%] xs:w-[80%] md:w-[50%]">
+    <div className="relative w-[78%] xs:w-[80%] md:w-[50%] flex flex-col">
       <form onSubmit={handleSearch} className="w-11/12 md:w-full">
-          <input
-            className="border-[0.5px] bg-custom-gray-50 rounded right-0 w-full h-9 md:h-10 pl-4 text-xs absolute top-[50%] translate-y-[-50%]"
-            type="text"
-            placeholder="검색어를 입력하세요."
-            onChange={handleKeywordChange}
-            value={searchInput}
-          />
-          <button
-            className="absolute right-0 md:right-1 top-[50%] translate-y-[-50%] md:r-1/12"
-            aria-label="검색하기"
-          >
-            <Image src={search} alt="검색 버튼" aria-hidden={true} />
-          </button>
+        <input
+          className="border-[0.5px] bg-custom-gray-50 rounded right-0 w-full h-9 md:h-10 pl-4 text-xs absolute top-[50%] translate-y-[-50%]"
+          type="text"
+          placeholder="검색어를 입력하세요."
+          onChange={handleKeywordChange}
+          value={searchInput}
+        />
+        <button
+          className="absolute right-0 md:right-1 top-[50%] translate-y-[-50%] md:r-1/12"
+          aria-label="검색하기"
+        >
+          <Image src={search} alt="검색 버튼" aria-hidden={true} />
+        </button>
       </form>
+      <div
+        className={`z-10 absolute top-[3.25rem] md:top-[3.75rem] w-full rounded-bl rounded-br bg-white shadow-lg`}
+      >
+        <SearchKeywords
+          keyword={keyword}
+          keywords={{ type: 'malls', data: keywords.malls }}
+        />
+        <SearchKeywords
+          keyword={keyword}
+          keywords={{ type: 'products', data: keywords.products }}
+        />
+      </div>
     </div>
   );
 }

--- a/components/SearchKeyword.tsx
+++ b/components/SearchKeyword.tsx
@@ -1,36 +1,55 @@
+'use client';
+
 import Image from 'next/image';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 type Props = {
   href: string;
   name: string;
   image: string;
   keyword: string;
+  setSearchInput: React.Dispatch<React.SetStateAction<string>>;
+  setKeyword: React.Dispatch<React.SetStateAction<string>>;
 };
 
-export default function SearchKeyword({ href, name, image, keyword }: Props) {
+export default function SearchKeyword({
+  href,
+  name,
+  image,
+  keyword,
+  setSearchInput,
+  setKeyword,
+}: Props) {
   const keywordIndex = name.indexOf(keyword);
+  const router = useRouter();
+
+  const handleKeywordClick = () => {
+    router.push(href);
+    setSearchInput('');
+    setKeyword('');
+  };
   return (
-    <li className="text-xs sm:text-sm pl-4 py-1 hover:bg-gray-50">
-      <Link className="flex gap-2" href={href}>
-        <Image
-          className="object-contain"
-          src={image}
-          alt=""
-          width={10}
-          height={10}
-        />
-        <div>
-          <span>{`${name.substring(0, keywordIndex)}`}</span>
-          <span className="font-semibold">{`${name.substring(
-            keywordIndex,
-            keywordIndex + keyword.length
-          )}`}</span>
-          <span className="truncate">{`${name.substring(
-            keywordIndex + keyword.length
-          )}`}</span>
-        </div>
-      </Link>
+    <li
+      onClick={handleKeywordClick}
+      className="flex gap-2 text-xs sm:text-sm pl-4 py-1 hover:bg-gray-50"
+    >
+      <Image
+        className="object-contain"
+        src={image}
+        alt=""
+        width={10}
+        height={10}
+      />
+      <div>
+        <span>{`${name.substring(0, keywordIndex)}`}</span>
+        <span className="font-semibold">{`${name.substring(
+          keywordIndex,
+          keywordIndex + keyword.length
+        )}`}</span>
+        <span className="truncate">{`${name.substring(
+          keywordIndex + keyword.length
+        )}`}</span>
+      </div>
     </li>
   );
 }

--- a/components/SearchKeyword.tsx
+++ b/components/SearchKeyword.tsx
@@ -31,14 +31,14 @@ export default function SearchKeyword({
   return (
     <li
       onClick={handleKeywordClick}
-      className="flex gap-2 text-xs sm:text-sm pl-4 py-1 hover:bg-gray-50"
+      className="flex items-center gap-2 text-xs sm:text-sm pl-4 py-1 hover:bg-gray-50"
     >
       <Image
         className="object-contain"
         src={image}
         alt=""
-        width={10}
-        height={10}
+        width={30}
+        height={30}
       />
       <div>
         <span>{`${name.substring(0, keywordIndex)}`}</span>

--- a/components/SearchKeyword.tsx
+++ b/components/SearchKeyword.tsx
@@ -1,0 +1,36 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+type Props = {
+  href: string;
+  name: string;
+  image: string;
+  keyword: string;
+};
+
+export default function SearchKeyword({ href, name, image, keyword }: Props) {
+  const keywordIndex = name.indexOf(keyword);
+  return (
+    <li className="text-xs sm:text-sm pl-4 py-1 hover:bg-gray-50">
+      <Link className="flex gap-2" href={href}>
+        <Image
+          className="object-contain"
+          src={image}
+          alt=""
+          width={10}
+          height={10}
+        />
+        <div>
+          <span>{`${name.substring(0, keywordIndex)}`}</span>
+          <span className="font-semibold">{`${name.substring(
+            keywordIndex,
+            keywordIndex + keyword.length
+          )}`}</span>
+          <span className="truncate">{`${name.substring(
+            keywordIndex + keyword.length
+          )}`}</span>
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/components/SearchKeywords.tsx
+++ b/components/SearchKeywords.tsx
@@ -35,7 +35,7 @@ export default function SearchKeywords({
         {data.map((result) => (
           <SearchKeyword
             key={result.id}
-            href={`/${type}/${result.id}`}
+            href={`/${type}/${type === 'malls' ? result.name : result.id}`}
             name={result.name}
             image={result.image}
             keyword={keyword}

--- a/components/SearchKeywords.tsx
+++ b/components/SearchKeywords.tsx
@@ -28,7 +28,7 @@ export default function SearchKeywords({
 
   return (
     <div>
-      <span className="block text-xs pl-4 py-1">
+      <span className="block text-xs pl-4 py-2 text-custom-gray-800">
         {type === 'malls' ? '쇼핑몰' : '상품'}
       </span>
       <ul className="">

--- a/components/SearchKeywords.tsx
+++ b/components/SearchKeywords.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { Malls, Products } from '@/service/search';
+import SearchKeyword from './SearchKeyword';
+
+type Props = {
+  keyword: string;
+  keywords:
+    | {
+        type: 'malls';
+        data: Malls[];
+      }
+    | {
+        type: 'products';
+        data: Products[];
+      };
+};
+
+export default function SearchKeywords({
+  keyword,
+  keywords: { type, data },
+}: Props) {
+  if (data.length === 0) return null;
+
+  return (
+    <div>
+      <span className="block text-xs pl-4 py-1">
+        {type === 'malls' ? '쇼핑몰' : '상품'}
+      </span>
+      <ul className="">
+        {data.map((result) => (
+          <SearchKeyword
+            key={result.id}
+            href={`/${type}/${result.id}`}
+            name={result.name}
+            image={result.image}
+            keyword={keyword}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/SearchKeywords.tsx
+++ b/components/SearchKeywords.tsx
@@ -14,11 +14,15 @@ type Props = {
         type: 'products';
         data: Products[];
       };
+  setSearchInput: React.Dispatch<React.SetStateAction<string>>;
+  setKeyword: React.Dispatch<React.SetStateAction<string>>;
 };
 
 export default function SearchKeywords({
   keyword,
   keywords: { type, data },
+  setSearchInput,
+  setKeyword,
 }: Props) {
   if (data.length === 0) return null;
 
@@ -35,6 +39,8 @@ export default function SearchKeywords({
             name={result.name}
             image={result.image}
             keyword={keyword}
+            setSearchInput={setSearchInput}
+            setKeyword={setKeyword}
           />
         ))}
       </ul>

--- a/service/search.ts
+++ b/service/search.ts
@@ -1,4 +1,4 @@
-import { customFetch } from '@/utils/customFetch';
+import { serverFetch } from '@/utils/customFetch';
 
 export type Keywords = {
   products: {
@@ -14,7 +14,7 @@ export type Keywords = {
 };
 
 export async function getSearchKeywords(keyword: string): Promise<Keywords> {
-  const response = await customFetch(`/search/${keyword}`);
+  const response = await serverFetch(`/search/${keyword}`);
   if (!response.ok) {
     return { products: [], malls: [] };
   }

--- a/service/search.ts
+++ b/service/search.ts
@@ -1,16 +1,20 @@
 import { serverFetch } from '@/utils/customFetch';
 
+export type Products = {
+  id: number;
+  name: string;
+  image: string;
+};
+
+export type Malls = {
+  id: number;
+  name: string;
+  image: string;
+};
+
 export type Keywords = {
-  products: {
-    id: number;
-    name: string;
-    image: string;
-  }[];
-  malls: {
-    id: number;
-    name: string;
-    image: string;
-  }[];
+  products: Products[];
+  malls: Malls[];
 };
 
 export async function getSearchKeywords(keyword: string): Promise<Keywords> {


### PR DESCRIPTION
## 연관 검색어 API 호출
- **디바운싱을 이용한 연관 검색어 API 호출 구현**: 검색창에 입력이 되고 멈춘지 0.5초가 지난 후에만 연관 검색어 조회 API를 호출하도록 구현
- 연관 검색어는 로그인한 유저 정보가 필요 없는 API이므로 백엔드 측에서 **API 호출 시 토큰 없이 요청하도록 수정**하였고, 이에 맞게 호출 코드를 수정함

## 연관 검색어 렌더링 및 디자인
<p align="center">
<img width="400" alt="image" src="https://github.com/YeolJyeongKong/fittering-FE/assets/94180099/0446130e-272c-44f6-8bbb-a2ffecb9a50b">
</p>

- 연관 검색어 결과에서 쇼핑몰과 상품을 구분하여 표시
- 연관 검색어에서 입력값과 같은 부분은 굵은 글씨로 표시
- 연관 검색어 클릭 시 해당 쇼핑몰/상품 상세 페이지로 이동하도록 라우터 설정
- 검색창에서 엔터키 입력 혹은 돋보기 클릭을 하여 검색 결과 페이지로 이동하거나, 연관 검색어를 클릭하여 쇼핑몰/상품 상세 페이지로 이동한 경우 입력값을 초기화시키도록 함 