### PR TITLE
비밀번호 재발급 기능 개발

### DIFF
--- a/app/(auth)/find/password/page.tsx
+++ b/app/(auth)/find/password/page.tsx
@@ -1,0 +1,26 @@
+import FindPasswordForm from '@/components/Form/FindPasswordForm';
+import Image from 'next/image';
+import React from 'react';
+import logo from '/public/Fittering_logo.png';
+
+type Props = {};
+
+function FindPasswordPage(props: Props) {
+  return (
+    <div className="flex flex-grow flex-col text-center pt-[5rem] px-4 min-h-[calc(100vh-1rem)] max-w-[400px] ml-auto mr-auto">
+      <h1 className="text-3xl font-bold">
+        <Image
+          className="w-1/3 block m-auto mt-6"
+          src={logo}
+          alt="핏터링 로고"
+        />
+      </h1>
+      <h2 className="mt-4 mb-12 text-xs sm:text-base md:text-lg font-semibold">
+        비밀번호를 찾고자하는 이메일을 입력해주세요.
+      </h2>
+      <FindPasswordForm />
+    </div>
+  );
+}
+
+export default FindPasswordPage;

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -36,8 +36,8 @@ function LoginPage(props: Props) {
           <SocialLogin />
           <Link
             className="text-custom-gray-500 text-sm"
-            href=""
-            aria-label="비밀번호 찾기로 이동"
+            href="/find/password"
+            aria-label="비밀번호 재발급으로 이동"
           >
             비밀번호를 잊으셨나요?
           </Link>

--- a/components/Form/FindPasswordForm.tsx
+++ b/components/Form/FindPasswordForm.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function FindPasswordForm() {
+  const [email, setEmail] = useState('');
+
+  const onEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(e.target.value);
+  };
+
+  const handleEmailCheck = async () => {};
+
+  const handleFindPassword = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+  };
+
+  return (
+    <form onSubmit={handleFindPassword}>
+      <input
+        className="border rounded-lg px-2 py-2.5 block mx-auto w-full text-sm sm:text-base"
+        type="email"
+        placeholder="이메일을 입력해주세요."
+        maxLength={64}
+        onChange={onEmailChange}
+        required
+      />
+      <button
+        className="bg-main-color w-full text-white p-2 rounded-lg font-bold text-sm sm:text-bases mt-4 disabled:opacity-75"
+        disabled={email.length ? false : true}
+      >
+        비밀번호 재발급
+      </button>
+    </form>
+  );
+}

--- a/components/Form/FindPasswordForm.tsx
+++ b/components/Form/FindPasswordForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { findPassword, isEmailValid } from '@/service/auth';
 import { useState } from 'react';
 
 export default function FindPasswordForm() {
@@ -9,10 +10,20 @@ export default function FindPasswordForm() {
     setEmail(e.target.value);
   };
 
-  const handleEmailCheck = async () => {};
-
   const handleFindPassword = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if (await isEmailValid(email)) {
+      const response = await findPassword(email);
+      if (response.status === 200) {
+        window.alert('이메일로 임시 비밀번호를 발송하였습니다.');
+      } else if (response.status === 400) {
+        window.alert('비밀번호 찾기는 1시간에 한 번 가능합니다.');
+      } else {
+        window.alert('비밀번호 재발급에 실패하였습니다.');
+      }
+    } else {
+      window.alert('일치하는 메일이 없습니다.');
+    }
   };
 
   return (

--- a/service/auth.ts
+++ b/service/auth.ts
@@ -1,4 +1,5 @@
 import { BASE_URL } from '@/constants/apis';
+import { serverFetch } from '@/utils/customFetch';
 
 type User = {
   username: string;
@@ -56,5 +57,22 @@ export async function login({
 
   if (response.ok) localStorage.setItem('TOKEN', token);
 
+  return response;
+}
+
+export async function isEmailValid(email: string) {
+  const response = await serverFetch(`/email/check?email=${email}`, {
+    method: 'post',
+  });
+  if (response.ok) {
+    return true;
+  }
+  return false;
+}
+
+export async function findPassword(email: string): Promise<Response> {
+  const response = await serverFetch(`/password/send?email=${email}`, {
+    method: 'post',
+  });
   return response;
 }


### PR DESCRIPTION
## API 연결
- 유저 메일 검증(POST) : `/email/check`
- 임시 패스워드 발급(POST) : `/password/send`

입력된 이메일이 유효한지 먼저 검증한 후, 유효한 이메일일 경우 임시 패스워드 발급 요청

## 기타
- 비밀번호 재발급 페이지 개발
- 로그인 페이지에 '비밀번호를 잊으셨나요?'에 비밀번호 재발급 페이지 링크 연결

### UI
![image](https://github.com/YeolJyeongKong/fittering-FE/assets/94180099/ae47bd71-e836-452e-943c-783f622aabfc)
