### PR TITLE
로그인 시 잘못 redirect 되는 버그 픽스

### DIFF
--- a/utils/customFetch.ts
+++ b/utils/customFetch.ts
@@ -1,18 +1,18 @@
 import { AUTH_URL, BASE_URL } from '@/constants/apis';
 
-const accessToken =
-  typeof window !== 'undefined' ? localStorage.getItem('TOKEN') : null;
-
-const defaultHeaders = {
-  'Content-Type': 'application/json',
-  Authorization: `${accessToken}`,
-};
-
 export async function customFetch(
   url: string,
   options?: RequestInit,
   isFileUpload?: boolean
 ): Promise<Response> {
+  const accessToken =
+    typeof window !== 'undefined' ? localStorage.getItem('TOKEN') : null;
+
+  const defaultHeaders = {
+    'Content-Type': 'application/json',
+    Authorization: `${accessToken}`,
+  };
+
   const headers = isFileUpload
     ? { Authorization: `${accessToken}`, ...options?.headers }
     : { ...defaultHeaders, ...options?.headers };


### PR DESCRIPTION
## 로그인 시 다시 로그인 페이지로 redirect 되는 버그 픽스
<img width="400" src="https://github.com/YeolJyeongKong/fittering-FE/assets/94180099/6dcc6380-fb52-48ae-9bae-11c14b50a2bb">

- API 요청 시 헤더를 콘솔에 찍어보니 `Authorization`가 `null`인 것을 확인
- `localStorage`에 있는 토큰을 가져와서 `Authorization` 헤더를 설정하는 코드가 `customFetch` 외부에 있어 `null`로 초기화된 상태에서 그대로 토큰 값을 넣어  API 요청을 보낸 후 401 응답을 받아 redirect 된 것으로 추정

 → `localStorage`에 있는 토큰을 가져와서 `Authorization` 헤더를 설정하는 코드를 `customFetch` 내부로 이동함으로써 해결

