### PR TITLE
상품 전체 보기 추가 개발

### DIFF
--- a/app/(service)/categories/[[...categoryName]]/page.tsx
+++ b/app/(service)/categories/[[...categoryName]]/page.tsx
@@ -2,7 +2,6 @@ import GlobalFilter from '@/components/GlobalFilter';
 import GlobalMenu from '@/components/GlobalMenu';
 import React from 'react';
 import CategoryProducts from '@/components/Products/CategoryProducts';
-import { getCategoriesProductsData } from '@/service/categoriesProducts';
 
 type Props = {
   params: {
@@ -10,18 +9,13 @@ type Props = {
   };
 };
 
-export const revalidate = 1209600; // 3600 * 24 * 14
+export const dynamic = 'force-dynamic';
 
 async function CategoryPage({ params: { categoryName } }: Props) {
-  const mainCategoriesProducts = await getCategoriesProductsData('main');
-  const subCategoriesProducts = await getCategoriesProductsData('sub');
-
   return (
     <div>
       <CategoryProducts
         categoryName={categoryName === undefined ? [] : categoryName}
-        mainCategoriesProducts={mainCategoriesProducts}
-        subCategoriesProducts={subCategoriesProducts}
       />
       <GlobalFilter />
       <GlobalMenu />

--- a/app/(service)/malls/[mallName]/page.tsx
+++ b/app/(service)/malls/[mallName]/page.tsx
@@ -5,7 +5,6 @@ import { mallNameToMallId } from '@/utils/mallNameToMallId';
 import MallIntroduction from '@/components/Mall/MallIntroduction';
 import MainCategoryNavbar from '@/components/Navbar/MainCategoryNavbar';
 import SubCategoryNavbar from '@/components/Navbar/SubCategoryNavbar';
-import { getCategoriesProductsData } from '@/service/categoriesProducts';
 import CategoryProducts from '@/components/Products/CategoryProducts';
 
 type Props = {
@@ -14,28 +13,17 @@ type Props = {
   };
 };
 
-export const revalidate = 1209600; // 3600*24*14
+export const dynamic = 'force-dynamic';
 
 async function MallPage({ params: { mallName } }: Props) {
   const mallId = mallNameToMallId(decodeURI(mallName));
-  const mallMainCategoriesProducts = await getCategoriesProductsData(
-    'main',
-    await mallId
-  );
-  const mallSubCategoriesProducts = await getCategoriesProductsData(
-    'sub',
-    await mallId
-  );
 
   return (
     <div>
       <MallIntroduction mallId={mallId} />
       <MainCategoryNavbar mallName={decodeURI(mallName)} />
       <SubCategoryNavbar mallName={decodeURI(mallName)} />
-      <CategoryProducts
-        mainCategoriesProducts={mallMainCategoriesProducts}
-        subCategoriesProducts={mallSubCategoriesProducts}
-      />
+      <CategoryProducts mallId={mallId} />
       <GlobalFilter />
       <GlobalMenu />
     </div>

--- a/app/(service)/user/recommendation/page.tsx
+++ b/app/(service)/user/recommendation/page.tsx
@@ -1,9 +1,51 @@
-import React from 'react';
+'use client';
+
+import Section from '@/components/Section';
+import { useAppSelector } from '@/store/hooks';
+import { MyPage } from '@/types/user';
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { ProductPreview, getProductPreview } from '@/service/product';
+import ProductsGrid from '@/components/Products/ProductsGrid';
 
 type Props = {};
 
 function RecommendationPage(props: Props) {
-  return <div>상품 추천 페이지</div>;
+  const myPage: MyPage = useAppSelector((state) => state.myPage);
+  const searchParam = useSearchParams();
+  const recommendationType = parseInt(searchParam.get('type') ?? '1');
+
+  const [products, setProducts] = useState<ProductPreview[]>([]);
+
+  const sectionName =
+    recommendationType === 1
+      ? `${myPage.username}님을 위한 추천 상품`
+      : `${myPage.username}님과 비슷한 체형의 고객의 pick`;
+
+  useEffect(() => {
+    async function fetchProducts() {
+      const data = await getProductPreview(
+        `/users/recommendation${recommendationType === 2 ? '/pick' : ''}`
+      );
+      setProducts(data);
+    }
+    fetchProducts();
+  }, [recommendationType, products]);
+
+  if (products.length === 0) {
+    return (
+      <div className="mt-8 text-center text-custom-gray-800">
+        추천 상품이 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <Section sectionName={sectionName} />
+      <ProductsGrid products={products} />
+    </div>
+  );
 }
 
 export default RecommendationPage;

--- a/components/PagingArrowButton.tsx
+++ b/components/PagingArrowButton.tsx
@@ -1,0 +1,25 @@
+import Image from "next/image";
+
+type Props = {
+  arrowSrc: string;
+  isActive: boolean;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+};
+
+export default function PagingArrowButton({
+  arrowSrc,
+  isActive,
+  onClick
+}: Props) {
+  
+  return (
+    <button
+      onClick={onClick}
+      className={`relative rounded-full border h-5 w-5 xs:h-6 xs:w-6 mx-[5px] ${
+        isActive ? 'font-semibold' : 'hidden'
+      }`}
+    >
+      <Image className='absolute translate-x-[-50%] left-[50%] translate-y-[-50%] top-[50%] inline object-center' src={arrowSrc} alt='' />
+    </button>
+  );
+}

--- a/components/PagingArrowButton.tsx
+++ b/components/PagingArrowButton.tsx
@@ -1,25 +1,33 @@
-import Image from "next/image";
+import Image from 'next/image';
 
 type Props = {
+  type: '이전' | '다음';
   arrowSrc: string;
   isActive: boolean;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
 };
 
 export default function PagingArrowButton({
+  type,
   arrowSrc,
   isActive,
-  onClick
+  onClick,
 }: Props) {
-  
   return (
     <button
       onClick={onClick}
       className={`relative rounded-full border h-5 w-5 xs:h-6 xs:w-6 mx-[5px] ${
-        isActive ? 'font-semibold' : 'hidden'
+        isActive ? '' : 'hidden'
       }`}
+      type="button"
+      aria-label={`${type} 페이지 보기`}
     >
-      <Image className='absolute translate-x-[-50%] left-[50%] translate-y-[-50%] top-[50%] inline object-center' src={arrowSrc} alt='' />
+      <Image
+        className="absolute translate-x-[-50%] left-[50%] translate-y-[-50%] top-[50%] inline object-center"
+        src={arrowSrc}
+        alt=""
+        aria-hidden={true}
+      />
     </button>
   );
 }

--- a/components/MainPage/ProductRecommendation.tsx
+++ b/components/MainPage/ProductRecommendation.tsx
@@ -8,6 +8,7 @@ import ProductsGrid from '@/components/Products/ProductsGrid';
 import ProductNotFound from '@/components//Products/ProductNotFound';
 import { useAppSelector } from '@/store/hooks';
 import { MyPage } from '@/types/user';
+import AllLink from './AllLink';
 
 type Props = {
   recommendationType: 1 | 2;
@@ -22,7 +23,7 @@ export default function ProductRecommendation({ recommendationType }: Props) {
     recommendationType === 1
       ? `${myPage.username}님을 위한 추천 상품`
       : `${myPage.username}님과 비슷한 체형의 고객의 pick`;
-      
+
   useEffect(() => {
     const blankOrPick = recommendationType === 2 ? '/pick' : '';
     async function fetchProduct() {
@@ -32,7 +33,7 @@ export default function ProductRecommendation({ recommendationType }: Props) {
       setProducts(data);
     }
     fetchProduct();
-    setIsMobile(typeof window !== 'undefined' && window.innerWidth < 640)
+    setIsMobile(typeof window !== 'undefined' && window.innerWidth < 640);
   }, [recommendationType]);
 
   return (
@@ -41,7 +42,11 @@ export default function ProductRecommendation({ recommendationType }: Props) {
         <ProductNotFound sectionName={sectionName} />
       ) : (
         <>
-          <Section sectionName={sectionName} />
+          <Section sectionName={sectionName}>
+            <AllLink
+              href={`/user/recommendation?type=${recommendationType}`}
+            />
+          </Section>
           {isMobile ? (
             <ProductSlider products={products} />
           ) : (

--- a/components/PageButton.tsx
+++ b/components/PageButton.tsx
@@ -1,0 +1,20 @@
+type Props = {
+  page: number | '<' | '>';
+  isActive: boolean;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+};
+
+export default function PageButton({ page, isActive, onClick }: Props) {
+  return (
+    <button
+      onClick={onClick}
+      className={`rounded-full border h-6 w-6 xs:h-8 xs:w-8 mx-[3px] ${
+        isActive
+          ? 'font-semibold bg-bean-color border-bean-color text-white'
+          : ''
+      }`}
+    >
+      {page}
+    </button>
+  );
+}

--- a/components/PageButton.tsx
+++ b/components/PageButton.tsx
@@ -13,6 +13,9 @@ export default function PageButton({ page, isActive, onClick }: Props) {
           ? 'font-semibold bg-bean-color border-bean-color text-white'
           : ''
       }`}
+      type="button"
+      aria-pressed={isActive}
+      aria-label={`${page} 페이지로 이동`}
     >
       {page}
     </button>

--- a/components/PageNavigator.tsx
+++ b/components/PageNavigator.tsx
@@ -55,6 +55,7 @@ export default function PageNavigator({
   return (
     <div className="flex items-center justify-center text-center my-12">
       <PagingArrowButton
+        type="이전"
         arrowSrc={leftArrow}
         isActive={start !== 1}
         onClick={() => {
@@ -70,6 +71,7 @@ export default function PageNavigator({
         />
       ))}
       <PagingArrowButton
+        type="다음"
         arrowSrc={rightArrow}
         isActive={end !== Math.ceil(productCount / 20)}
         onClick={() => {

--- a/components/PageNavigator.tsx
+++ b/components/PageNavigator.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { serverFetch } from '@/utils/customFetch';
+import { CategoryCount } from '@/types/categories';
+import { useState, useEffect } from 'react';
+import PageButton from './PageButton';
+import PagingArrowButton from './\bPagingArrowButton';
+import leftArrow from '/public/icon/left_black.svg';
+import rightArrow from '/public/icon/right_black.svg';
+
+type Props = {
+  categoryType: keyof CategoryCount;
+  categoryId: number;
+  currentPage: number;
+  setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
+  mallId?: Promise<number>;
+};
+
+export default function PageNavigator({
+  categoryType,
+  categoryId,
+  currentPage,
+  setCurrentPage,
+  mallId,
+}: Props) {
+  const [categoryCount, setCategoryCount] = useState<CategoryCount>(
+    {} as CategoryCount
+  );
+
+  useEffect(() => {
+    async function fetchCategoryCount() {
+      const data = await (
+        await serverFetch(
+          `${mallId ? `/malls/${mallId}` : ''}/categories/count`
+        )
+      ).json();
+      setCategoryCount(data);
+    }
+    fetchCategoryCount();
+  }, [mallId]);
+
+  const productCount =
+    categoryCount[categoryType]?.find(
+      (category) => category.categoryId === categoryId
+    )?.count ?? Infinity;
+
+  const start = Math.floor((currentPage - 1) / 5) * 5 + 1;
+  const end = Math.min(start + 4, Math.ceil(productCount / 20));
+
+  let pages = [];
+  for (let page = start; page <= end; page++) {
+    pages.push(page);
+  }
+
+  return (
+    <div className="flex items-center justify-center text-center my-12">
+      <PagingArrowButton
+        arrowSrc={leftArrow}
+        isActive={start !== 1}
+        onClick={() => {
+          setCurrentPage(Math.floor((currentPage - 6) / 5) * 5 + 5);
+        }}
+      />
+      {pages.map((page) => (
+        <PageButton
+          key={page}
+          page={page}
+          isActive={page === currentPage}
+          onClick={() => setCurrentPage(page)}
+        />
+      ))}
+      <PagingArrowButton
+        arrowSrc={rightArrow}
+        isActive={end !== Math.ceil(productCount / 20)}
+        onClick={() => {
+          setCurrentPage(
+            Math.min(
+              Math.floor((currentPage + 4) / 5) * 5 + 1,
+              Math.ceil(productCount / 20)
+            )
+          );
+        }}
+      />
+    </div>
+  );
+}

--- a/components/Products/CategoryProducts.tsx
+++ b/components/Products/CategoryProducts.tsx
@@ -10,6 +10,7 @@ import {
   fetchCategoriesProducts,
   fetchMallCategoriesProducts,
 } from '@/service/categoriesProducts';
+import PageNavigator from '../PageNavigator';
 
 type Props = {
   categoryName?: string[];
@@ -32,7 +33,7 @@ export default function CategoryProducts({ categoryName, mallId }: Props) {
   const categoryId = categoryNameToIndex(categoryName ?? mallCategoryName);
   const gender = localStorage.getItem('GLOBAL_FILTER') ?? 'A';
   const [filterId, setFilterId] = useState(0);
-  const [page, setPage] = useState(1);
+  const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(() => {
     async function fetchProduct() {
@@ -44,7 +45,7 @@ export default function CategoryProducts({ categoryName, mallId }: Props) {
             categoryId,
             gender,
             filterId,
-            page
+            currentPage
           )
         );
       } else {
@@ -54,13 +55,13 @@ export default function CategoryProducts({ categoryName, mallId }: Props) {
             categoryId,
             gender,
             filterId,
-            page
+            currentPage
           )
         );
       }
     }
     fetchProduct();
-  }, [categoryType, categoryId, gender, mallId, filterId, page]);
+  }, [categoryType, categoryId, gender, mallId, filterId, currentPage]);
 
   if (products.length === 0) {
     return (
@@ -74,6 +75,13 @@ export default function CategoryProducts({ categoryName, mallId }: Props) {
     <>
       <FilterIdDropdown setFilterId={setFilterId} />
       <ProductsGrid products={products} />
+      <PageNavigator
+        categoryType={categoryType}
+        categoryId={categoryId}
+        currentPage={currentPage}
+        setCurrentPage={setCurrentPage}
+        mallId={mallId}
+      />
     </>
   );
 }

--- a/public/icon/right_black.svg
+++ b/public/icon/right_black.svg
@@ -1,0 +1,3 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.0711 7.99999L19.1421 15.0711L12.0711 22.1421" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/service/categoriesProducts.ts
+++ b/service/categoriesProducts.ts
@@ -1,57 +1,30 @@
-import { outer, top, dress, bottom } from '@/types/categories';
-import { FILTER_ID } from '@/constants/filterId';
 import { getProductPreviewPagingWithoutToken } from '@/service/product';
-import { CategoryProductsData } from '@/types/categoryProducts';
 
-export const categories = [outer, top, dress, bottom];
-const mainCategoryId = [0, ...categories.map((category) => category.index)];
-const subCategoryId = categories
-  .map((category) => category.sub.map((sub) => sub.index))
-  .flat();
-const genders: ('A' | 'M' | 'F')[] = ['A', 'M', 'F'];
-const filterIds = FILTER_ID.map((filter) => filter.id);
-
-async function fetchCategoriesProducts(
+export async function fetchCategoriesProducts(
   categoryType: 'main' | 'sub',
   categoryId: number,
   gender: string,
   filterId: number,
-  mallId?: number
+  page: number
 ) {
-  const apiUrl = mallId
-    ? `/malls${categoryType === 'sub' ? '/sub' : ''}/${mallId}`
-    : `/categories${categoryType === 'sub' ? '/sub' : ''}`;
-  
   return await getProductPreviewPagingWithoutToken(
-    `${apiUrl}/${categoryId}/${gender}/${filterId}`
+    `/categories${
+      categoryType === 'sub' ? '/sub' : ''
+    }/${categoryId}/${gender}/${filterId}?page=${page}`
   );
 }
 
-export async function getCategoriesProductsData(
+export async function fetchMallCategoriesProducts(
+  mallId: number,
   categoryType: 'main' | 'sub',
-  mallId?: number
+  categoryId: number,
+  gender: string,
+  filterId: number,
+  page: number
 ) {
-  const categoryIds = categoryType === 'main' ? mainCategoryId : subCategoryId;
-  let data: CategoryProductsData[] = [];
-
-  for (const categoryId of categoryIds) {
-    for (const gender of genders) {
-      for (const filterId of filterIds) {
-        data.push({
-          categoryId: categoryId,
-          gender: gender,
-          filterId: filterId,
-          contents: await fetchCategoriesProducts(
-            categoryType,
-            categoryId,
-            gender,
-            filterId,
-            mallId
-          ),
-        });
-      }
-    }
-  }
-
-  return data;
+  return await getProductPreviewPagingWithoutToken(
+    `/malls${
+      categoryType === 'sub' ? '/sub' : ''
+    }/${mallId}/${categoryId}/${gender}/${filterId}?page=${page}`
+  );
 }

--- a/types/categories.ts
+++ b/types/categories.ts
@@ -100,3 +100,14 @@ export const bottom: Category = {
     },
   ],
 };
+
+export type CategoryCount = {
+  main: {
+    categoryId: number;
+    count: number;
+  }[];
+  sub: {
+    categoryId: number;
+    count: number;
+  }[];
+};

--- a/types/categoryProducts.ts
+++ b/types/categoryProducts.ts
@@ -1,8 +1,0 @@
-import { ProductPreview } from '@/service/product';
-
-export type CategoryProductsData = {
-  categoryId: number;
-  gender: 'A' | 'M' | 'F';
-  filterId: number;
-  contents: ProductPreview[]
-}

--- a/utils/categoryNameToIndex.ts
+++ b/utils/categoryNameToIndex.ts
@@ -3,6 +3,7 @@ import { bottom, dress, outer, top } from '@/types/categories';
 const categories = [outer, top, dress, bottom];
 
 export const categoryNameToIndex = (categoryName: string[]) => {
+  if (categoryName.length === 0) return 0;
   const mainCategory = categories.filter(
     (category) => category.url === `/categories/${categoryName[0]}`
   )[0];


### PR DESCRIPTION
## 추천 상품 전체 보기 추가
- 메인 페이지에서 추천 상품 / 비슷한 체형의 고객의 pick 전체 보기 클릭 시 추천 상품 전체 보기 페이지로 이동

## 페이징
- 카테고리별 상품 조회 페이지에서 서버 컴포넌트에서 data fetch를 해놓은 뒤 자식 클라이언트 컴포넌트에서 필터링해서 보여주던 기존 방식에서 클라이언트 컴포넌트에서 선택된 카테고리, 성별, 정렬 기준, 페이지에 따라서 요청을 보내고 상품을 렌더링하도록 수정
- 페이징 기능 개발 및 `aria` 속성 작성 완료

### UI
<img width="277" alt="image" src="https://github.com/YeolJyeongKong/fittering-FE/assets/94180099/ca9dfa7d-9b84-4282-ae04-b7dcf6f8875d">
