### PR TITLE
쇼핑몰 전체 조회 페이지 추가

### DIFF
--- a/app/(service)/malls/favorite_malls/page.tsx
+++ b/app/(service)/malls/favorite_malls/page.tsx
@@ -1,3 +1,4 @@
+import LinkToMallsList from '@/components/Malls/LinkToMallsList';
 import MallPreviewFilter from '@/components/Malls/MallPreviewFilter';
 import MallsList from '@/components/Malls/MallsList';
 import React from 'react';
@@ -8,6 +9,7 @@ function FavoriteMallPage(props: Props) {
   return (
     <div>
       <MallPreviewFilter isRanking={false} />
+      <LinkToMallsList />
       <MallsList isRanking={false} />
     </div>
   );

--- a/app/(service)/malls/list/page.tsx
+++ b/app/(service)/malls/list/page.tsx
@@ -1,0 +1,20 @@
+import { getMallsPreviewList } from '@/service/malls';
+import React from 'react';
+import MallPreviewCard from '@/components/Malls/MallPreviewCard';
+import Section from '@/components/Section';
+
+type Props = {};
+
+async function MallsListPage(props: Props) {
+  const mallsList = await getMallsPreviewList();
+  
+  return (
+    <div>
+      <Section sectionName="쇼핑몰 전체 보기" />
+      <div className="my-4" aria-hidden={true}></div>
+      <MallPreviewCard malls={mallsList} />
+    </div>
+  );
+}
+
+export default MallsListPage;

--- a/app/(service)/malls/page.tsx
+++ b/app/(service)/malls/page.tsx
@@ -1,3 +1,4 @@
+import LinkToMallsList from '@/components/Malls/LinkToMallsList';
 import MallPreviewFilter from '@/components/Malls/MallPreviewFilter';
 import MallsList from '@/components/Malls/MallsList';
 import React from 'react';
@@ -8,6 +9,7 @@ function MallsPage(props: Props) {
   return (
     <div>
       <MallPreviewFilter isRanking={true} />
+      <LinkToMallsList />
       <MallsList isRanking={true} />
     </div>
   );

--- a/components/Malls/LinkToMallsList.tsx
+++ b/components/Malls/LinkToMallsList.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link';
+
+export default function LinkToMallsList() {
+  return (
+    <div className="text-right mb-2">
+      <Link
+        href="/malls/list"
+        className="text-xs text-custom-gray-400"
+      >{`쇼핑몰 전체 보기 >`}</Link>
+    </div>
+  );
+}

--- a/components/Malls/MallPreviewFilter.tsx
+++ b/components/Malls/MallPreviewFilter.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export default function MallPreviewFilter({ isRanking }: Props) {
   return (
-    <div className="flex gap-1.5 justify-center items-center text-center my-4">
+    <div className="flex gap-1.5 justify-center items-center text-center mt-4 mb-2">
       <MallPreviewFilterLink isRanking={true} isSelected={isRanking} />
       <MallPreviewFilterLink isRanking={false} isSelected={!isRanking} />
     </div>

--- a/components/Malls/RankedMallPreview.tsx
+++ b/components/Malls/RankedMallPreview.tsx
@@ -23,7 +23,7 @@ export default function RankedMallPreview() {
           <span className="block text-custom-gray-800 my-4 text-sm">
             방문한 쇼핑몰이 없습니다.
           </span>
-          <LinkButton href="/malls" guide="쇼핑몰 전체 보기" />
+          <LinkButton href="/malls/list" guide="쇼핑몰 전체 보기" />
         </>
       )}
     </div>

--- a/service/malls.ts
+++ b/service/malls.ts
@@ -88,3 +88,13 @@ export async function getMallsList(): Promise<
   }
   return response.json();
 }
+
+export async function getMallsPreviewList(): Promise<MallPreview[]> {
+  const response = await serverFetch('/malls/preview/list', {
+    next: { revalidate: 3600 },
+  });
+  if (!response.ok) {
+    return [];
+  }
+  return response.json();
+}


### PR DESCRIPTION
## 쇼핑몰 전체 조회 페이지 추가
- 쇼핑몰 전체 조회 페이지 `/malls/list` 추가

- 커스텀 쇼핑몰 랭킹 조회 페이지 / 즐겨찾기 쇼핑몰 조회 페이지에 쇼핑몰 전체 보기 링크 추가 
  <img width="1045" alt="image" src="https://github.com/YeolJyeongKong/fittering-FE/assets/94180099/218e7630-ea7f-4809-bb0f-226e73da86fd">

- 회원 가입한 후 방문한 쇼핑몰 기록이 없는 유저의 경우 나타나는 아래 사진의 쇼핑몰 전체 보기 버튼 클릭 시 이동하는 URL 커스텀 쇼핑몰 랭킹 조회 페이지(`/malls`)가 아닌 쇼핑몰 전체 조회 페이지(`/malls/list`)로 연결되도록 수정
  ![image](https://github.com/YeolJyeongKong/fittering-FE/assets/94180099/4fffa88f-a886-408d-a144-8c528f08f994)


## API 연결
- 쇼핑몰 전체 리스트 조회(GET) : `/malls/preview/list`