### PR TITLE
버그 픽스 : 로딩 UI, 유저 정보 전역 state, 페이징, 연관검색어 등

### DIFF
--- a/app/(service)/categories/[[...categoryName]]/page.tsx
+++ b/app/(service)/categories/[[...categoryName]]/page.tsx
@@ -9,8 +9,6 @@ type Props = {
   };
 };
 
-export const dynamic = 'force-dynamic';
-
 async function CategoryPage({ params: { categoryName } }: Props) {
   return (
     <div>

--- a/app/(service)/loading.tsx
+++ b/app/(service)/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p>Loading...</p>;
+}

--- a/app/(service)/malls/[mallName]/page.tsx
+++ b/app/(service)/malls/[mallName]/page.tsx
@@ -13,8 +13,6 @@ type Props = {
   };
 };
 
-export const dynamic = 'force-dynamic';
-
 async function MallPage({ params: { mallName } }: Props) {
   const mallId = mallNameToMallId(decodeURI(mallName));
 

--- a/app/(service)/user/page.tsx
+++ b/app/(service)/user/page.tsx
@@ -2,21 +2,14 @@
 
 import FavoriteProducts from '@/components/FavoriteProducts';
 import RecentProducts from '@/components/MyPage/RecentProducts';
-import { useAppDispatch, useAppSelector } from '@/store/hooks';
-import { fetchMyPage } from '@/store/myPageAction';
+import { useAppSelector } from '@/store/hooks';
 import { MyPage } from '@/types/user';
 import Link from 'next/link';
-import React, { useEffect } from 'react';
 import MyPageCommon from '../../../components/MyPage/MyPageCommon';
 
 type Props = {};
 function MyPage(props: Props) {
-  const dispatch = useAppDispatch();
   const myPage: MyPage = useAppSelector((state) => state.myPage);
-
-  useEffect(() => {
-    dispatch(fetchMyPage());
-  }, [dispatch]);
 
   return (
     <>

--- a/app/(service)/user/recommendation/page.tsx
+++ b/app/(service)/user/recommendation/page.tsx
@@ -30,7 +30,7 @@ function RecommendationPage(props: Props) {
       setProducts(data);
     }
     fetchProducts();
-  }, [recommendationType, products]);
+  }, [recommendationType]);
 
   if (products.length === 0) {
     return (

--- a/components/MainPage/ProductRecommendation.tsx
+++ b/components/MainPage/ProductRecommendation.tsx
@@ -6,9 +6,10 @@ import { useEffect, useState } from 'react';
 import ProductSlider from '@/components/Products/ProductSlider';
 import ProductsGrid from '@/components/Products/ProductsGrid';
 import ProductNotFound from '@/components//Products/ProductNotFound';
-import { useAppSelector } from '@/store/hooks';
+import { useAppSelector, useAppDispatch } from '@/store/hooks';
 import { MyPage } from '@/types/user';
 import AllLink from './AllLink';
+import { fetchMyPage } from '@/store/myPageAction';
 
 type Props = {
   recommendationType: 1 | 2;
@@ -17,7 +18,13 @@ type Props = {
 export default function ProductRecommendation({ recommendationType }: Props) {
   const [products, setProducts] = useState<ProductPreview[]>([]);
   const [isMobile, setIsMobile] = useState<boolean>(false);
+
+  const dispatch = useAppDispatch();
   const myPage: MyPage = useAppSelector((state) => state.myPage);
+
+  useEffect(() => {
+    dispatch(fetchMyPage());
+  }, [dispatch]);
 
   const sectionName =
     recommendationType === 1

--- a/components/MainPage/ProductsRank.tsx
+++ b/components/MainPage/ProductsRank.tsx
@@ -4,7 +4,7 @@ import RankFilter from './RankFilter';
 
 async function fetchRank(gender: 'A' | 'M' | 'F') {
   return await getProductPreviewWithoutToken(`/products/rank/${gender}`, {
-    next: { revalidate: 3600 * 24 },
+    next: { revalidate: 86400 },  // 24시간
   });
 }
 

--- a/components/Products/CategoryProducts.tsx
+++ b/components/Products/CategoryProducts.tsx
@@ -36,6 +36,10 @@ export default function CategoryProducts({ categoryName, mallId }: Props) {
   const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(() => {
+    setCurrentPage(1);
+  }, [categoryId]);
+
+  useEffect(() => {
     async function fetchProduct() {
       if (mallId) {
         setProducts(

--- a/components/SearchKeyword.tsx
+++ b/components/SearchKeyword.tsx
@@ -31,7 +31,7 @@ export default function SearchKeyword({
   return (
     <li
       onClick={handleKeywordClick}
-      className="flex items-center gap-2 text-xs sm:text-sm pl-4 py-1 hover:bg-gray-50"
+      className="flex items-center gap-2 text-xs sm:text-sm px-4 py-1 hover:bg-gray-50"
     >
       <Image
         className="object-contain"
@@ -40,13 +40,13 @@ export default function SearchKeyword({
         width={30}
         height={30}
       />
-      <div>
+      <div className='truncate'>
         <span>{`${name.substring(0, keywordIndex)}`}</span>
         <span className="font-semibold">{`${name.substring(
           keywordIndex,
           keywordIndex + keyword.length
         )}`}</span>
-        <span className="truncate">{`${name.substring(
+        <span>{`${name.substring(
           keywordIndex + keyword.length
         )}`}</span>
       </div>


### PR DESCRIPTION
### 버그 픽스
- 로딩 UI 추가
- 연관검색어가 긴 경우 글자가 밖으로 튀어나오지 않고 잘리도록 처리
- 쇼핑몰 내 카테고리별 상품 조회에서 카테고리 변경 시 페이징 번호 1로 초기화하도록 수정
- 유저 정보 전역 state 초기화 시점을 마이 페이지 진입 시에서 메인 페이지 진입 시로 수정
- 추천 상품 조회 페이지의 `useEffect`에 불필요한 dependency array 요소 제거하여 불필요한 API 호출을 하지 않도록 수정
- `revalidate` 코드 수정