### PR TITLE
쇼핑몰 전체 조회 페이지 수정

### DIFF
--- a/app/(service)/malls/favorite_malls/page.tsx
+++ b/app/(service)/malls/favorite_malls/page.tsx
@@ -10,7 +10,7 @@ function FavoriteMallPage(props: Props) {
     <div>
       <MallPreviewFilter isRanking={false} />
       <LinkToMallsList />
-      <MallsList isRanking={false} />
+      <MallsList previewType='favorite_malls' />
     </div>
   );
 }

--- a/app/(service)/malls/list/page.tsx
+++ b/app/(service)/malls/list/page.tsx
@@ -1,18 +1,15 @@
-import { getMallsPreviewList } from '@/service/malls';
 import React from 'react';
-import MallPreviewCard from '@/components/Malls/MallPreviewCard';
 import Section from '@/components/Section';
+import MallsList from '@/components/Malls/MallsList';
 
 type Props = {};
 
-async function MallsListPage(props: Props) {
-  const mallsList = await getMallsPreviewList();
-  
+async function MallsListPage(props: Props) {  
   return (
     <div>
       <Section sectionName="쇼핑몰 전체 보기" />
       <div className="my-4" aria-hidden={true}></div>
-      <MallPreviewCard malls={mallsList} />
+      <MallsList previewType='preview/list' />
     </div>
   );
 }

--- a/app/(service)/malls/page.tsx
+++ b/app/(service)/malls/page.tsx
@@ -10,7 +10,7 @@ function MallsPage(props: Props) {
     <div>
       <MallPreviewFilter isRanking={true} />
       <LinkToMallsList />
-      <MallsList isRanking={true} />
+      <MallsList previewType='rank' />
     </div>
   );
 }

--- a/components/Malls/MallsList.tsx
+++ b/components/Malls/MallsList.tsx
@@ -5,18 +5,18 @@ import { getMalls, MallPreview } from '@/service/malls';
 import { useState, useEffect } from 'react';
 
 type Props = {
-  isRanking: boolean;
+  previewType: 'rank' | 'favorite_malls' | 'preview/list';
 };
 
-export default function MallsList({ isRanking }: Props) {
+export default function MallsList({ previewType }: Props) {
   const [malls, setMalls] = useState<MallPreview[]>([]);
 
   useEffect(() => {
     async function fetchMalls() {
-      const data = await getMalls(isRanking ? 'rank' : 'favorite_malls');
+      const data = await getMalls(previewType);
       setMalls(data);
     }
     fetchMalls();
-  }, [isRanking]);
+  }, [previewType]);
   return <MallPreviewCard malls={malls} />;
 }

--- a/service/malls.ts
+++ b/service/malls.ts
@@ -88,13 +88,3 @@ export async function getMallsList(): Promise<
   }
   return response.json();
 }
-
-export async function getMallsPreviewList(): Promise<MallPreview[]> {
-  const response = await serverFetch('/malls/preview/list', {
-    next: { revalidate: 3600 },
-  });
-  if (!response.ok) {
-    return [];
-  }
-  return response.json();
-}

--- a/service/malls.ts
+++ b/service/malls.ts
@@ -39,7 +39,7 @@ export async function getRankedMallPreview(): Promise<MallRankingPreview[]> {
 }
 
 export async function getMalls(
-  filter: 'rank' | 'favorite_malls'
+  filter: 'rank' | 'favorite_malls' | 'preview/list'
 ): Promise<MallPreview[]> {
   const response = await customFetch(`/malls/${filter}`);
   if (!response.ok) {


### PR DESCRIPTION
### 쇼핑몰 전체 조회 페이지 수정
- 기존의 쇼핑몰 전체 조회 API가 토큰이 필요 없는 API였으나, 쇼핑몰 즐겨찾기 추가를 할 수 없어 유저 정보가 필요하여 백엔드 측에서 토큰이 필요한 API로 수정하였음
- 이에 따라 쇼핑몰 전체 조회 API를 호출할 때 유저 토큰 정보를 담아서 요청하도록 수정 필요

→ 쇼핑몰 랭킹/ 즐겨찾기 쇼핑몰과 동일하게 API 요청을 하면 되므로 동일한 함수를 사용하여 호출하도록 하고 이를 위해 쇼핑몰 리스트 컴포넌트의 props를 수정함